### PR TITLE
Updated partfait to use guava 18.0

### DIFF
--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/ThreadCounter.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/ThreadCounter.java
@@ -46,7 +46,7 @@ public interface ThreadCounter extends ThreadValue<AtomicLong>, Counter {
 
         @Override
         public void inc(long increment) {
-            map.get(Thread.currentThread()).addAndGet(increment);
+            loadingCache.getUnchecked(Thread.currentThread()).addAndGet(increment);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
           <dependency>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
-              <version>r07</version>
+              <version>18.0</version>
           </dependency>
           <dependency>
               <groupId>org.mockito</groupId>


### PR DESCRIPTION
MapMaker.makeComputingMap has been deprecated (see https://code.google.com/p/guava-libraries/wiki/MapMakerMigration). As the link suggests, I've updated references of the created map to use a CacheLoader instead.