### PR TITLE
Fix logical error in ParfaitConnectionHandler which causes stack overflow

### DIFF
--- a/parfait-jdbc/src/main/java/com/custardsource/parfait/jdbc/ParfaitDataSource.java
+++ b/parfait-jdbc/src/main/java/com/custardsource/parfait/jdbc/ParfaitDataSource.java
@@ -1,13 +1,5 @@
 package com.custardsource.parfait.jdbc;
 
-import com.custardsource.parfait.timing.ThreadMetric;
-import com.custardsource.parfait.timing.ThreadValue;
-import com.custardsource.parfait.timing.ThreadValueMetric;
-import com.google.common.collect.ImmutableList;
-
-import javax.measure.unit.SI;
-import javax.measure.unit.Unit;
-import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -20,6 +12,14 @@ import java.sql.Statement;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
+import javax.measure.unit.SI;
+import javax.measure.unit.Unit;
+import javax.sql.DataSource;
+
+import com.custardsource.parfait.timing.ThreadMetric;
+import com.custardsource.parfait.timing.ThreadValue;
+import com.custardsource.parfait.timing.ThreadValueMetric;
+import com.google.common.collect.ImmutableList;
 
 public class ParfaitDataSource implements DataSource {
 	private final DataSource wrapped;
@@ -101,7 +101,7 @@ public class ParfaitDataSource implements DataSource {
 						|| "prepareCall".equals(methodName)) {
 					return proxyStatement((Statement) method.invoke(wrapped, args));
 				}
-				return method.invoke(proxy, args);
+				return method.invoke(wrapped, args);
 			} catch (InvocationTargetException ex) {
 				throw ex.getTargetException();
 			}

--- a/parfait-jdbc/src/test/java/com/custardsource/parfait/jdbc/ParfaitDataSourceTest.java
+++ b/parfait-jdbc/src/test/java/com/custardsource/parfait/jdbc/ParfaitDataSourceTest.java
@@ -1,36 +1,42 @@
 package com.custardsource.parfait.jdbc;
 
+import static org.junit.Assert.assertEquals;
+
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import javax.sql.DataSource;
 
-import org.junit.Assert;
+import com.custardsource.parfait.timing.ThreadMetric;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 
-import com.custardsource.parfait.timing.ThreadMetric;
-
 public class ParfaitDataSourceTest {
-	private DataSource wrapped;
+	private ParfaitDataSource dataSource;
 
 	@Before
 	public void setUp() throws SQLException, ClassNotFoundException {
 		Class.forName("org.hsqldb.jdbcDriver");
 		Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:parfait", "sa", "");
-		wrapped = new SingleConnectionDataSource(c, false);
+		DataSource wrapped = new SingleConnectionDataSource(c, false);
+		dataSource = new ParfaitDataSource(wrapped);
 	}
 
 	@Test
 	public void testExecutionCountForCurrentThread() throws SQLException {
-		ParfaitDataSource source = new ParfaitDataSource(wrapped);
-		Statement s = source.getConnection().createStatement();
-		ThreadMetric counter = source.getCounterMetric();
-		Assert.assertEquals(0, counter.getValueForThread(Thread.currentThread()));
+		Statement s = dataSource.getConnection().createStatement();
+		ThreadMetric counter = dataSource.getCounterMetric();
+		assertEquals(0, counter.getValueForThread(Thread.currentThread()));
 		s.execute("ROLLBACK");
-        Assert.assertEquals(1, counter.getValueForThread(Thread.currentThread()));
+        assertEquals(1, counter.getValueForThread(Thread.currentThread()));
+	}
+
+	@Test
+	public void testExecutingNonProxiedMethod() throws SQLException {
+		DatabaseMetaData data = dataSource.getConnection().getMetaData();
+        assertEquals("HSQL Database Engine", data.getDatabaseProductName());
 	}
 }


### PR DESCRIPTION
There is a logical error in ParfaitConnectionHandler which should delegate client call to the wrapped connection, instead of the proxy object. Otherwise it causes stack overflow error.