### PR TITLE
Make count sub-metric in metered adapter use ".count" suffix in metri…

### DIFF
--- a/parfait-dropwizard/src/main/java/com/custardsource/parfait/dropwizard/metricadapters/MeteredAdapter.java
+++ b/parfait-dropwizard/src/main/java/com/custardsource/parfait/dropwizard/metricadapters/MeteredAdapter.java
@@ -19,7 +19,7 @@ public class MeteredAdapter implements MetricAdapter {
     private final NonSelfRegisteringSettableValue<Double> oneMinuteRate;
     private final NonSelfRegisteringSettableValue<Double> meanRate;
     private final NonSelfRegisteringSettableValue<Double> fifteenMinuteRate;
-    private final NonSelfRegisteringSettableValue<Long> rawCounter;
+    private final NonSelfRegisteringSettableValue<Long> count;
 
     public MeteredAdapter(Metered metered, String name, String description) {
         this.metered = metered;
@@ -27,12 +27,12 @@ public class MeteredAdapter implements MetricAdapter {
         this.fiveMinuteRate = new NonSelfRegisteringSettableValue<>(name(name, "five_minute_rate"), description + " - Five minute rate", Unit.ONE, metered.getFiveMinuteRate(), ValueSemantics.FREE_RUNNING);
         this.oneMinuteRate = new NonSelfRegisteringSettableValue<>(name(name, "one_minute_rate"), description + " - One minute rate", Unit.ONE, metered.getOneMinuteRate(), ValueSemantics.FREE_RUNNING);
         this.meanRate = new NonSelfRegisteringSettableValue<>(name(name, "mean_rate"), description + " - Mean rate", Unit.ONE, metered.getMeanRate(), ValueSemantics.FREE_RUNNING);
-        this.rawCounter = new NonSelfRegisteringSettableValue<>(name, description, Unit.ONE, metered.getCount(),ValueSemantics.MONOTONICALLY_INCREASING);
+        this.count = new NonSelfRegisteringSettableValue<>(name(name, "count"), description + " - Count", Unit.ONE, metered.getCount(), ValueSemantics.MONOTONICALLY_INCREASING);
     }
 
     @Override
     public Set<Monitorable> getMonitorables() {
-        return Sets.<Monitorable>newHashSet(fifteenMinuteRate, fiveMinuteRate, oneMinuteRate, meanRate, rawCounter);
+        return Sets.<Monitorable>newHashSet(fifteenMinuteRate, fiveMinuteRate, oneMinuteRate, meanRate, count);
     }
 
     @Override
@@ -41,6 +41,6 @@ public class MeteredAdapter implements MetricAdapter {
         fiveMinuteRate.set(metered.getFiveMinuteRate());
         oneMinuteRate.set(metered.getOneMinuteRate());
         meanRate.set(metered.getMeanRate());
-        rawCounter.set(metered.getCount());
+        count.set(metered.getCount());
     }
 }

--- a/parfait-dropwizard/src/main/java/com/custardsource/parfait/dropwizard/metricadapters/TimerAdapter.java
+++ b/parfait-dropwizard/src/main/java/com/custardsource/parfait/dropwizard/metricadapters/TimerAdapter.java
@@ -1,26 +1,21 @@
 package com.custardsource.parfait.dropwizard.metricadapters;
 
-import static com.codahale.metrics.MetricRegistry.name;
+import com.codahale.metrics.Timer;
+import com.custardsource.parfait.Monitorable;
+import com.custardsource.parfait.dropwizard.MetricAdapter;
+import com.google.common.collect.Sets;
 
 import javax.measure.unit.SI;
 import java.util.Set;
-
-import com.codahale.metrics.Timer;
-import com.custardsource.parfait.Monitorable;
-import com.custardsource.parfait.ValueSemantics;
-import com.custardsource.parfait.dropwizard.MetricAdapter;
-import com.google.common.collect.Sets;
 
 public class TimerAdapter implements MetricAdapter {
 
     private final MeteredAdapter meteredAdapter;
     private final SamplingAdapter samplingAdapter;
-    private final CountingAdapter countingAdapter;
 
     public TimerAdapter(Timer timer, String name, String description) {
         meteredAdapter = new MeteredAdapter(timer, name, description);
         samplingAdapter = new SamplingAdapter(timer, name, description, SI.NANO(SI.SECOND));
-        countingAdapter = new CountingAdapter(timer, name(name, "count"), description + " - Count", ValueSemantics.MONOTONICALLY_INCREASING);
     }
 
     @Override
@@ -28,7 +23,6 @@ public class TimerAdapter implements MetricAdapter {
         Set<Monitorable> allMonitorables = Sets.newHashSet();
         allMonitorables.addAll(meteredAdapter.getMonitorables());
         allMonitorables.addAll(samplingAdapter.getMonitorables());
-        allMonitorables.addAll(countingAdapter.getMonitorables());
         return allMonitorables;
     }
 
@@ -36,6 +30,5 @@ public class TimerAdapter implements MetricAdapter {
     public void updateMonitorables() {
         meteredAdapter.updateMonitorables();
         samplingAdapter.updateMonitorables();
-        countingAdapter.updateMonitorables();
     }
 }

--- a/parfait-dropwizard/src/test/java/com/custardsource/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/com/custardsource/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
@@ -59,7 +59,7 @@ public class MeteredAdapterTest {
         assertThat(extractMonitorables(meteredAdapter).get(FIFTEEN_MINUTE_RATE).getDescription(), is(DESCRIPTION + " - Fifteen minute rate"));
         assertThat(extractMonitorables(meteredAdapter).get(FIFTEEN_MINUTE_RATE).get(), Matchers.<Object>is(INITIAL_FIFTEEN_MINUTE_RATE));
         assertThat(extractMonitorables(meteredAdapter).get(FIFTEEN_MINUTE_RATE).getSemantics(), is(ValueSemantics.FREE_RUNNING));
-        assertThat(extractMonitorables(meteredAdapter).get(FIFTEEN_MINUTE_RATE).getUnit(), Matchers.<Unit<?>>is(Unit.ONE));
+        assertThat(extractMonitorables(meteredAdapter).get(FIFTEEN_MINUTE_RATE).getUnit(), Matchers.<Unit>is(Unit.ONE));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class MeteredAdapterTest {
         assertThat(extractMonitorables(meteredAdapter).get(FIVE_MINUTE_RATE).getDescription(), is(DESCRIPTION + " - Five minute rate"));
         assertThat(extractMonitorables(meteredAdapter).get(FIVE_MINUTE_RATE).get(), Matchers.<Object>is(INITIAL_FIVE_MINUTE_RATE));
         assertThat(extractMonitorables(meteredAdapter).get(FIVE_MINUTE_RATE).getSemantics(), is(ValueSemantics.FREE_RUNNING));
-        assertThat(extractMonitorables(meteredAdapter).get(FIVE_MINUTE_RATE).getUnit(), Matchers.<Unit<?>>is(Unit.ONE));
+        assertThat(extractMonitorables(meteredAdapter).get(FIVE_MINUTE_RATE).getUnit(), Matchers.<Unit>is(Unit.ONE));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class MeteredAdapterTest {
         assertThat(extractMonitorables(meteredAdapter).get(ONE_MINUTE_RATE).getDescription(), is(DESCRIPTION + " - One minute rate"));
         assertThat(extractMonitorables(meteredAdapter).get(ONE_MINUTE_RATE).get(), Matchers.<Object>is(INITIAL_ONE_MINUTE_RATE));
         assertThat(extractMonitorables(meteredAdapter).get(ONE_MINUTE_RATE).getSemantics(), is(ValueSemantics.FREE_RUNNING));
-        assertThat(extractMonitorables(meteredAdapter).get(ONE_MINUTE_RATE).getUnit(), Matchers.<Unit<?>>is(Unit.ONE));
+        assertThat(extractMonitorables(meteredAdapter).get(ONE_MINUTE_RATE).getUnit(), Matchers.<Unit>is(Unit.ONE));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class MeteredAdapterTest {
         assertThat(extractMonitorables(meteredAdapter).get(MEAN_RATE).getDescription(), is(DESCRIPTION + " - Mean rate"));
         assertThat(extractMonitorables(meteredAdapter).get(MEAN_RATE).get(), Matchers.<Object>is(INITIAL_MEAN_RATE));
         assertThat(extractMonitorables(meteredAdapter).get(MEAN_RATE).getSemantics(), is(ValueSemantics.FREE_RUNNING));
-        assertThat(extractMonitorables(meteredAdapter).get(MEAN_RATE).getUnit(), Matchers.<Unit<?>>is(Unit.ONE));
+        assertThat(extractMonitorables(meteredAdapter).get(MEAN_RATE).getUnit(), Matchers.<Unit>is(Unit.ONE));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class MeteredAdapterTest {
         assertThat(extractMonitorables(meteredAdapter).get(COUNT).getDescription(), is(DESCRIPTION + " - Count"));
         assertThat(extractMonitorables(meteredAdapter).get(COUNT).get(), Matchers.<Object>is(INITIAL_COUNT));
         assertThat(extractMonitorables(meteredAdapter).get(COUNT).getSemantics(), is(ValueSemantics.MONOTONICALLY_INCREASING));
-        assertThat(extractMonitorables(meteredAdapter).get(COUNT).getUnit(), Matchers.<Unit<?>>is(Unit.ONE));
+        assertThat(extractMonitorables(meteredAdapter).get(COUNT).getUnit(), Matchers.<Unit>is(Unit.ONE));
     }
 
     @Test


### PR DESCRIPTION
Have confirmed this fixes our bug where raw count metric caused other metrics from TimerAdapter to disappear