### PR TITLE
squid:S2325 - private methods that don't access instance data should be static

### DIFF
--- a/dxm/src/main/java/com/custardsource/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/com/custardsource/parfait/dxm/PcpMmvWriter.java
@@ -301,7 +301,7 @@ public class PcpMmvWriter extends BasePcpWriter {
         return flagMask;
     }
 
-    private void writeStringSection(ByteBuffer dataFileBuffer, String value) {
+    private static void writeStringSection(ByteBuffer dataFileBuffer, String value) {
     	byte[] bytes = value.getBytes(PCP_CHARSET);
     	Preconditions.checkArgument(bytes.length < STRING_BLOCK_LENGTH);
         dataFileBuffer.put(bytes);
@@ -383,7 +383,7 @@ public class PcpMmvWriter extends BasePcpWriter {
      *            the PcpValueInfo to be written to the file
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private void writeValueSection(ByteBuffer dataFileBuffer, PcpValueInfo info) {
+    private static void writeValueSection(ByteBuffer dataFileBuffer, PcpValueInfo info) {
         int originalPosition = dataFileBuffer.position();
         TypeHandler rawHandler = info.getTypeHandler();
         if (rawHandler.requiresLargeStorage()) {
@@ -399,7 +399,7 @@ public class PcpMmvWriter extends BasePcpWriter {
         dataFileBuffer.putLong(info.getInstanceOffset());
     }
 
-    private void writeInstanceSection(ByteBuffer dataFileBuffer, Instance instance) {
+    private static void writeInstanceSection(ByteBuffer dataFileBuffer, Instance instance) {
         dataFileBuffer.putLong(instance.getInstanceDomain().getOffset());
         dataFileBuffer.putInt(0);
         dataFileBuffer.putInt(instance.getId());
@@ -414,7 +414,7 @@ public class PcpMmvWriter extends BasePcpWriter {
         dataFileBuffer.putLong(getStringOffset(instanceDomain.getLongHelpText()));
     }
 
-    private long getStringOffset(PcpString text) {
+    private static long getStringOffset(PcpString text) {
         if (text == null) {
             return 0;
         }
@@ -428,7 +428,7 @@ public class PcpMmvWriter extends BasePcpWriter {
      *            the 0-based index of the TOC block to be written
      * @return the file offset used to store that TOC block (32-bit regardless of architecture)
      */
-    private final int getTocOffset(int tocIndex) {
+    private static final int getTocOffset(int tocIndex) {
         return HEADER_LENGTH + (tocIndex * TOC_LENGTH);
     }
 
@@ -460,7 +460,7 @@ public class PcpMmvWriter extends BasePcpWriter {
         initializeOffsets(getStrings(), nextOffset, STRING_BLOCK_LENGTH);
     }
 
-	private int initializeOffsets(Collection<? extends PcpOffset> offsettables,
+	private static int initializeOffsets(Collection<? extends PcpOffset> offsettables,
 			int nextOffset, int blockLength) {
         for (PcpOffset offsettable : offsettables) {
             offsettable.setOffset(nextOffset);
@@ -483,7 +483,7 @@ public class PcpMmvWriter extends BasePcpWriter {
     /**
      * @return the PID of the current running Java Process
      */
-    private int getPid() {
+    private static int getPid() {
         String processIdentifier = ManagementFactory.getRuntimeMXBean().getName();
         return Integer.valueOf(processIdentifier.split("@")[0]);
     }

--- a/dxm/src/main/java/com/custardsource/parfait/dxm/StringParsingIdentifierSourceSet.java
+++ b/dxm/src/main/java/com/custardsource/parfait/dxm/StringParsingIdentifierSourceSet.java
@@ -79,7 +79,7 @@ public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
                 .instanceDomainSource());
     }
 
-    private boolean isBlankOrComment(String currentLine) {
+    private static boolean isBlankOrComment(String currentLine) {
         return (currentLine.trim().isEmpty()) || (currentLine.trim().startsWith("#")); 
 	}
 
@@ -98,7 +98,7 @@ public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
         return instanceDomainSource.getInstanceSource(domain);
     }
 
-    private String parseAllocation(final BiMap<String, Integer> allocations, int lineNumber,
+    private static String parseAllocation(final BiMap<String, Integer> allocations, int lineNumber,
             String currentLine) {
         String[] elements = currentLine.trim().split("\\s+");
         if (elements.length != 2) {

--- a/parfait-benchmark/src/main/java/com/custardsource/parfait/benchmark/BlockedMetricCollector.java
+++ b/parfait-benchmark/src/main/java/com/custardsource/parfait/benchmark/BlockedMetricCollector.java
@@ -22,7 +22,7 @@ public class BlockedMetricCollector {
         this(Thread.currentThread().getId());
     }
 
-    private ThreadInfo getThreadInfo(long threadId) {
+    private static ThreadInfo getThreadInfo(long threadId) {
         return ManagementFactory.getThreadMXBean().getThreadInfo(threadId);
     }
     

--- a/parfait-benchmark/src/main/java/com/custardsource/parfait/benchmark/CPUThreadTest.java
+++ b/parfait-benchmark/src/main/java/com/custardsource/parfait/benchmark/CPUThreadTest.java
@@ -80,15 +80,15 @@ public class CPUThreadTest {
         System.out.printf("cpuTracingEnabled: %s\tcpuLookupMethod: %s\titerations/sec: %s\tblockedCount: %d\tblockedTime: %d\n", leftPadBoolean(cpuTracingEnabled), formatCpuLookupMethod(cpuLookupMethod), iterationsPerSecondString, totalBlockedCount, totalBlockedTime);
     }
 
-    private String formatCpuLookupMethod(CPUThreadTestRunner.CpuLookupMethod cpuLookupMethod) {
+    private static String formatCpuLookupMethod(CPUThreadTestRunner.CpuLookupMethod cpuLookupMethod) {
         return StringUtils.rightPad(cpuLookupMethod.name(), CPUThreadTestRunner.CpuLookupMethod.USE_CURRENT_THREAD_CPU_TIME.name().length());
     }
 
-    private String leftPadBoolean(boolean theBoolean) {
+    private static String leftPadBoolean(boolean theBoolean) {
         return StringUtils.leftPad(Boolean.toString(theBoolean), 5);
     }
 
-    private void awaitExecutionCompletion(ExecutorService executorService) {
+    private static void awaitExecutionCompletion(ExecutorService executorService) {
         try {
             executorService.shutdown();
             executorService.awaitTermination(1, TimeUnit.MINUTES);

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/EventTimer.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/EventTimer.java
@@ -125,7 +125,7 @@ public class EventTimer {
         return prefix + "." + cleanName(eventGroup) + "." + metric;
     }
 
-    private String cleanName(String eventGroup) {
+    private static String cleanName(String eventGroup) {
         // TODO do name cleanup elsewhere
         return eventGroup.replace("/", "");
     }

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/LoggerSink.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/LoggerSink.java
@@ -36,7 +36,7 @@ public class LoggerSink implements StepMeasurementSink {
 
     }
 
-    private String buildDepthString(int depth) {
+    private static String buildDepthString(int depth) {
         return (depth > 0) ? "Nested (" + depth + ")" : "Top";
     }
 

--- a/parfait-pcp/src/main/java/com/custardsource/parfait/pcp/StringParsingTextSource.java
+++ b/parfait-pcp/src/main/java/com/custardsource/parfait/pcp/StringParsingTextSource.java
@@ -13,7 +13,7 @@ public class StringParsingTextSource implements TextSource {
         delegate = new MapTextSource(fallback, parseMap(input));
     }
 
-    private Map<String, String> parseMap(Iterable<String> input) {
+    private static Map<String, String> parseMap(Iterable<String> input) {
         Map<String, String> output = Maps.newHashMap();
         int lineNumber = 0;
         for (String currentLine : input) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 private methods that don't access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava