### PR TITLE
squid:S1192 Staging/string literals should not be duplicated fix 1

### DIFF
--- a/dxm/src/main/java/com/custardsource/parfait/dxm/PcpMetricInfo.java
+++ b/dxm/src/main/java/com/custardsource/parfait/dxm/PcpMetricInfo.java
@@ -6,6 +6,9 @@ import com.custardsource.parfait.dxm.semantics.Semantics;
 import com.custardsource.parfait.dxm.types.TypeHandler;
 
 final class PcpMetricInfo implements PcpId, PcpOffset {
+    private static final String OLD = " (old=";
+    private static final String NEW = ", new=";
+
     private final String metricName;
     private final int id;
 
@@ -62,7 +65,7 @@ final class PcpMetricInfo implements PcpId, PcpOffset {
         if (this.domain != null && !this.domain.equals(domain)) {
             throw new IllegalArgumentException(
                     "Two different instance domains cannot be set for metric " + metricName
-                            + " (old=" + this.domain + ", new=" + domain + ")");
+                            + OLD + this.domain + NEW + domain + ")");
         }
         this.domain = domain;
     }
@@ -84,7 +87,7 @@ final class PcpMetricInfo implements PcpId, PcpOffset {
         if (this.unit != null && !this.unit.equals(unit)) {
             throw new IllegalArgumentException(
                     "Two different units cannot be set for metric " + metricName
-                    + " (old=" + this.unit + ", new=" + unit + ")");
+                    + OLD + this.unit + NEW + unit + ")");
         }
         this.unit = unit;
     }
@@ -97,7 +100,7 @@ final class PcpMetricInfo implements PcpId, PcpOffset {
         if (this.semantics != null && semantics != this.semantics) {
             throw new IllegalArgumentException(
                     "Two different semantics cannot be set for metric " + metricName
-                    + " (old=" + this.semantics + ", new=" + semantics + ")");
+                    + OLD + this.semantics + NEW + semantics + ")");
         }
         this.semantics = semantics;
     }

--- a/dxm/src/main/java/com/custardsource/parfait/dxm/StringParsingIdentifierSourceSet.java
+++ b/dxm/src/main/java/com/custardsource/parfait/dxm/StringParsingIdentifierSourceSet.java
@@ -8,6 +8,8 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 
 public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
+    private static final String ERROR_PARSING_LINE = "Error parsing line ";
+
     private final IdentifierSourceSet fallbacks;
     private final IdentifierSource metricSource;
     private final InstanceDomainIdentifierSource instanceDomainSource;
@@ -55,7 +57,7 @@ public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
                 // This is an instance, not an indom
                 if (currentDomain == null) {
                     throw new IllegalArgumentException(
-                            "Error parsing line "
+                            ERROR_PARSING_LINE
                                     + lineNumber
                                     + " of input; leading whitespace should only be used for instance values under an instance domain");
                 }
@@ -102,7 +104,7 @@ public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
             String currentLine) {
         String[] elements = currentLine.trim().split("\\s+");
         if (elements.length != 2) {
-            throw new IllegalArgumentException("Error parsing line " + lineNumber
+            throw new IllegalArgumentException(ERROR_PARSING_LINE + lineNumber
                     + " of input; should have two columns in format <name><whitespace><id>");
         }
         String metricName = elements[0];
@@ -110,12 +112,12 @@ public class StringParsingIdentifierSourceSet implements IdentifierSourceSet {
         try {
             id = Integer.valueOf(elements[1]);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Error parsing line " + lineNumber
+            throw new IllegalArgumentException(ERROR_PARSING_LINE + lineNumber
                     + " of input; identifier " + metricName + " has unparseable ID string '"
                     + elements[1] + "'");
         }
         if (allocations.containsValue(id)) {
-            throw new IllegalArgumentException("Error parsing line " + lineNumber
+            throw new IllegalArgumentException(ERROR_PARSING_LINE + lineNumber
                     + " of input; identifier " + metricName + " has ID " + id
                     + " which is already in use for identifier " + allocations.inverse().get(id));
         }

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
@@ -17,6 +17,9 @@ import com.google.common.collect.Lists;
 
 public class InProgressSnapshot {
     private static final Logger LOG = LoggerFactory.getLogger(InProgressSnapshot.class);
+    private static final String EVENT = "Event";
+    private static final String THREAD_ID = "Thread ID";
+    private static final String THREAD_NAME = "Thread name";
 
     private final List<String> names = new ArrayList<String>();
     private final List<String> descriptions = new ArrayList<String>();
@@ -24,16 +27,16 @@ public class InProgressSnapshot {
     private final List<Map<String, Object>> values = Lists.newArrayList();
 
     private InProgressSnapshot(EventTimer timer, ThreadContext context) {
-        names.add("Thread name");
-        descriptions.add("Thread name");
+        names.add(THREAD_NAME);
+        descriptions.add(THREAD_NAME);
         classes.add(String.class);
 
-        names.add("Thread ID");
-        descriptions.add("Thread ID");
+        names.add(THREAD_ID);
+        descriptions.add(THREAD_ID);
         classes.add(Long.class);
 
-        names.add("Event");
-        descriptions.add("Event");
+        names.add(EVENT);
+        descriptions.add(EVENT);
         classes.add(String.class);
 
         for (ThreadMetric metric : timer.getMetricSuite().metrics()) {
@@ -55,16 +58,16 @@ public class InProgressSnapshot {
                 .entrySet()) {
             StepMeasurements m = entry.getValue().getInProgressMeasurements();
             if (m != null) {
-                String event = m.getBackTrace();
+                String eventLocal = m.getBackTrace();
                 Map<ThreadMetric, Long> snapshotValues = m.snapshotValues();
                 Map<String, Object> keyedValues = new HashMap<String, Object>();
-                keyedValues.put("Thread name", entry.getKey().getName());
-                keyedValues.put("Thread ID", entry.getKey().getId());
-                keyedValues.put("Event", event);
+                keyedValues.put(THREAD_NAME, entry.getKey().getName());
+                keyedValues.put(THREAD_ID, entry.getKey().getId());
+                keyedValues.put(EVENT, eventLocal);
                 for (ThreadMetric metric : timer.getMetricSuite().metrics()) {
                     keyedValues.put(metric.getMetricName(), snapshotValues.get(metric));
                     LOG.trace(String.format("Thread %s in event %s, metric %s has value %s", entry
-                            .getKey(), event, metric, snapshotValues.get(metric)));
+                            .getKey(), eventLocal, metric, snapshotValues.get(metric)));
                 }
                 for (String contextEntry : contextKeys) {
                     keyedValues.put(contextEntry, String.valueOf(context.getForThread(entry


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 Staging literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava