### PR TITLE
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/dxm/src/main/java/com/custardsource/parfait/dxm/IdentifierSourceSet.java
+++ b/dxm/src/main/java/com/custardsource/parfait/dxm/IdentifierSourceSet.java
@@ -1,10 +1,6 @@
 package com.custardsource.parfait.dxm;
 
 public interface IdentifierSourceSet {
-    public IdentifierSource instanceDomainSource();
-    public IdentifierSource instanceSource(String domain);
-    public IdentifierSource metricSource();
-    
     public static IdentifierSourceSet DEFAULT_SET = new IdentifierSourceSet() {
         private final IdentifierSource instanceDomainSource = new HashingIdentifierSource(1 << 22);
         private final IdentifierSource instanceSource = new HashingIdentifierSource(Integer.MAX_VALUE);
@@ -49,7 +45,7 @@ public interface IdentifierSourceSet {
             return ERROR_SOURCE;
         }
     };
-
+    
     /**
      * An IdentifierSourceSet for use in contexts where identifiers truly do not matter and are not limited in range
      * -- e.g. test cases or writers which do not need to limit identifiers
@@ -72,4 +68,9 @@ public interface IdentifierSourceSet {
             return defaultSource;
         }
     };
+    
+    public IdentifierSource instanceDomainSource();
+    public IdentifierSource instanceSource(String domain);
+    public IdentifierSource metricSource();
+    
 }

--- a/parfait-core/src/main/java/com/custardsource/parfait/Counter.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/Counter.java
@@ -1,10 +1,6 @@
 package com.custardsource.parfait;
 
 public interface Counter {
-    void inc();
-    
-    void inc(long increment);
-
     public static final Counter NULL_COUNTER = new Counter(){
         @Override
         public void inc() {
@@ -14,4 +10,7 @@ public interface Counter {
         public void inc(long increment) {
         }
     };
+    void inc();
+    
+    void inc(long increment);
 }

--- a/parfait-core/src/main/java/com/custardsource/parfait/Counter.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/Counter.java
@@ -10,6 +10,7 @@ public interface Counter {
         public void inc(long increment) {
         }
     };
+    
     void inc();
     
     void inc(long increment);

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/DummyEventTimer.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/DummyEventTimer.java
@@ -36,6 +36,7 @@ public final class DummyEventTimer extends EventTimer {
         super("dummy", new MonitorableRegistry(), ThreadMetricSuite.blank(), false, false,
                 Collections.<StepMeasurementSink>emptyList());
     }
+    
     public EventMetricCollector getCollector() {
         return DUMMY_EVENT_METRIC_COLLECTOR;
     }

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/DummyEventTimer.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/DummyEventTimer.java
@@ -9,11 +9,6 @@ import com.custardsource.parfait.MonitorableRegistry;
  * A dummy EventTimer which implements all functionality as no-ops.
  */
 public final class DummyEventTimer extends EventTimer {
-    public DummyEventTimer() {
-        super("dummy", new MonitorableRegistry(), ThreadMetricSuite.blank(), false, false,
-                Collections.<StepMeasurementSink>emptyList());
-    }
-
     private static final EventMetricCollector DUMMY_EVENT_METRIC_COLLECTOR = new EventMetricCollector(
             null, Collections.<StepMeasurementSink>emptyList()) {
         @Override
@@ -37,6 +32,10 @@ public final class DummyEventTimer extends EventTimer {
         }
     };
 
+    public DummyEventTimer() {
+        super("dummy", new MonitorableRegistry(), ThreadMetricSuite.blank(), false, false,
+                Collections.<StepMeasurementSink>emptyList());
+    }
     public EventMetricCollector getCollector() {
         return DUMMY_EVENT_METRIC_COLLECTOR;
     }

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class InProgressSnapshot {
+    private static final Logger LOG = LoggerFactory.getLogger(InProgressSnapshot.class);
     public static final Function<InProgressSnapshot, String> TO_TABBED_STRING = new InProgressFormatter();
     public static final Function<InProgressSnapshot, String> TO_FORMATTED_STRING = new InProgressFormatter() {
         @Override
@@ -23,7 +24,6 @@ public class InProgressSnapshot {
             return Strings.padStart(value, 20, ' ');
         }
     };
-    private static final Logger LOG = LoggerFactory.getLogger(InProgressSnapshot.class);
     
     private final List<String> names = new ArrayList<String>();
     private final List<String> descriptions = new ArrayList<String>();

--- a/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
+++ b/parfait-core/src/main/java/com/custardsource/parfait/timing/InProgressSnapshot.java
@@ -16,8 +16,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class InProgressSnapshot {
+    public static final Function<InProgressSnapshot, String> TO_TABBED_STRING = new InProgressFormatter();
+    public static final Function<InProgressSnapshot, String> TO_FORMATTED_STRING = new InProgressFormatter() {
+        @Override
+        protected String formatColumnValue(String value) {
+            return Strings.padStart(value, 20, ' ');
+        }
+    };
     private static final Logger LOG = LoggerFactory.getLogger(InProgressSnapshot.class);
-
+    
     private final List<String> names = new ArrayList<String>();
     private final List<String> descriptions = new ArrayList<String>();
     private final List<Class<?>> classes = new ArrayList<Class<?>>();
@@ -132,13 +139,4 @@ public class InProgressSnapshot {
             return value;
         }
     }
-
-    public static final Function<InProgressSnapshot, String> TO_TABBED_STRING = new InProgressFormatter();
-
-    public static final Function<InProgressSnapshot, String> TO_FORMATTED_STRING = new InProgressFormatter() {
-        @Override
-        protected String formatColumnValue(String value) {
-            return Strings.padStart(value, 20, ' ');
-        }
-    };
 }

--- a/parfait-io/src/main/java/com/custardsource/parfait/io/ByteCountingInputStream.java
+++ b/parfait-io/src/main/java/com/custardsource/parfait/io/ByteCountingInputStream.java
@@ -11,6 +11,14 @@ public class ByteCountingInputStream extends ProxyInputStream {
 
 	private final Counter byteCounter;
 
+    public ByteCountingInputStream(InputStream streamToWrap,
+            Counter counter) {
+        super(streamToWrap);
+        Preconditions.checkNotNull(counter, "MonitoredCounter cannot be null");
+        Preconditions.checkNotNull(streamToWrap, "InputStream cannot be null");
+        this.byteCounter = counter;
+    }
+
     @Override
     public int read(byte[] bts, int st, int end) throws IOException {
         int read = super.read(bts, st, end);
@@ -26,13 +34,7 @@ public class ByteCountingInputStream extends ProxyInputStream {
 
     }
 
-    public ByteCountingInputStream(InputStream streamToWrap,
-			Counter counter) {
-	    super(streamToWrap);
-	    Preconditions.checkNotNull(counter, "MonitoredCounter cannot be null");
-	    Preconditions.checkNotNull(streamToWrap, "InputStream cannot be null");
-		this.byteCounter = counter;
-	}
+    
 	
 	@Override
 	public int read() throws IOException {

--- a/parfait-io/src/main/java/com/custardsource/parfait/io/ByteCountingInputStream.java
+++ b/parfait-io/src/main/java/com/custardsource/parfait/io/ByteCountingInputStream.java
@@ -31,15 +31,12 @@ public class ByteCountingInputStream extends ProxyInputStream {
         int read = super.read(bts);
         eosSafeCountingRead(read);
         return read;
-
     }
-
     
-	
-	@Override
-	public int read() throws IOException {
-	    int readByte = super.read();
-	    /*
+    @Override
+    public int read() throws IOException {
+        int readByte = super.read();
+        /*
          * the other read methods return the # bytes read, not the actual byte like this one does so
          * if we've reached EOS, we don't increment the counter, otherwise we do.
          */
@@ -52,6 +49,4 @@ public class ByteCountingInputStream extends ProxyInputStream {
             byteCounter.inc(numRead);
         }
     }
-
-
 }

--- a/parfait-jmx/src/main/java/com/custardsource/parfait/jmx/JmxInProgressMonitor.java
+++ b/parfait-jmx/src/main/java/com/custardsource/parfait/jmx/JmxInProgressMonitor.java
@@ -24,27 +24,6 @@ import com.google.common.collect.Lists;
 
 @ManagedResource
 public class JmxInProgressMonitor {
-    private final InProgressExporter exporter;
-
-    public JmxInProgressMonitor(InProgressExporter exporter) {
-        this.exporter = exporter;
-    }
-    
-    @ManagedAttribute
-    public TabularData getInProgressOperations() {
-        return TO_TABULAR_DATA.apply(exporter.getSnapshot());
-    }
-
-    @ManagedAttribute
-    public String getSnapshotAsString() {
-        return exporter.getSnapshot().asTabbedString();
-    }
-
-    @ManagedAttribute
-    public String getFormattedSnapshot() {
-        return exporter.getSnapshot().asFormattedString();
-    }
-
     private static final Function<Class<?>, OpenType<?>> CLASS_TO_OPENTYPE = new Function<Class<?>, OpenType<?>>() {
         private final Map<Class<?>, SimpleType<?>> mappings = ImmutableMap
                 .<Class<?>, SimpleType<?>> of(String.class, SimpleType.STRING, Long.class,
@@ -55,7 +34,7 @@ public class JmxInProgressMonitor {
             return mappings.get(from);
         }
     };
-
+    
     static final Function<InProgressSnapshot, TabularData> TO_TABULAR_DATA = new Function<InProgressSnapshot, TabularData>() {
         @Override
         public TabularData apply(InProgressSnapshot from) {
@@ -81,5 +60,25 @@ public class JmxInProgressMonitor {
             }
         }
     };
+    
+    private final InProgressExporter exporter;
 
+    public JmxInProgressMonitor(InProgressExporter exporter) {
+        this.exporter = exporter;
+    }
+    
+    @ManagedAttribute
+    public TabularData getInProgressOperations() {
+        return TO_TABULAR_DATA.apply(exporter.getSnapshot());
+    }
+
+    @ManagedAttribute
+    public String getSnapshotAsString() {
+        return exporter.getSnapshot().asTabbedString();
+    }
+
+    @ManagedAttribute
+    public String getFormattedSnapshot() {
+        return exporter.getSnapshot().asFormattedString();
+    }
 }

--- a/parfait-pcp/src/main/java/com/custardsource/parfait/pcp/MetricNameMapper.java
+++ b/parfait-pcp/src/main/java/com/custardsource/parfait/pcp/MetricNameMapper.java
@@ -6,12 +6,12 @@ import com.custardsource.parfait.dxm.MetricName;
  * Maps a String to a PCP {@link MetricName}.
  */
 public interface MetricNameMapper {
-	MetricName map(String name);
-	
 	static final MetricNameMapper PASSTHROUGH_MAPPER = new MetricNameMapper() {
 		@Override
 		public MetricName map(String name) {
 			return MetricName.parse(name);
 		}
 	};
+	
+	MetricName map(String name);
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava