### PR TITLE
Fix non-weak reference regression introduced with Guava upgrade

### DIFF
--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValue.java
@@ -49,7 +49,7 @@ public interface ThreadValue<T> {
 
     public static class WeakReferenceThreadMap<T> implements ThreadValue<T> {
 
-        protected final LoadingCache<Thread, T> loadingCache = CacheBuilder.newBuilder().build(new CacheLoader<Thread, T>() {
+        protected final LoadingCache<Thread, T> loadingCache = CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<Thread, T>() {
             @Override
             public T load(Thread thread) throws Exception {
                 return initialValue();


### PR DESCRIPTION
In 0c858c81ed70c36d4ee598eab742221b93b001d5, this map was migrated to
LoadingCache. The weakKeys() builder method accidentally got dropped and
the defaults are to hold strong references. This commit re-introduces the
weakKeys() builder method for the LoadingCache.