### PR TITLE
Move forward to mandating JDK 1.8 as the baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Parfait is a performance monitoring library for Java which extracts metrics and 
 
 # Requirements
 
-Parfait requires Java 7.
+Parfait requires Java 8.
 
 # About parfait
 

--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -30,8 +30,8 @@
       <artifactId>unit-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>tec.units</groupId>
-      <artifactId>unit-ri</artifactId>
+      <groupId>tec.uom</groupId>
+      <artifactId>uom-se</artifactId>
     </dependency>
     <dependency>
         <groupId>systems.uom</groupId>

--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
         <groupId>systems.uom</groupId>
-        <artifactId>systems-unicode</artifactId>
+        <artifactId>systems-unicode-java8</artifactId>
     </dependency>
     <dependency>
     	<groupId>commons-lang</groupId>

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
@@ -5,11 +5,11 @@ import static io.pcp.parfait.dxm.MmvVersion.MMV_VERSION1;
 import static io.pcp.parfait.dxm.PcpString.STRING_BLOCK_LENGTH;
 import static io.pcp.parfait.dxm.PcpString.STRING_BLOCK_LIMIT;
 import static systems.uom.unicode.CLDR.BYTE;
-import static tec.units.ri.unit.MetricPrefix.KILO;
-import static tec.units.ri.unit.Units.HERTZ;
-import static tec.units.ri.unit.Units.HOUR;
-import static tec.units.ri.unit.Units.SECOND;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.unit.MetricPrefix.KILO;
+import static tec.uom.se.unit.Units.HERTZ;
+import static tec.uom.se.unit.Units.HOUR;
+import static tec.uom.se.unit.Units.SECOND;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.io.File;
 import java.io.IOException;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpScale.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpScale.java
@@ -1,8 +1,8 @@
 package io.pcp.parfait.dxm.semantics;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
-import tec.units.ri.unit.Units;
+import tec.uom.se.unit.Units;
 
 import systems.uom.quantity.Information;
 import systems.uom.unicode.CLDR;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
@@ -2,10 +2,10 @@ package io.pcp.parfait.dxm.semantics;
 
 import static systems.uom.unicode.CLDR.BIT;
 import static systems.uom.unicode.CLDR.BYTE;
-import static tec.units.ri.AbstractConverter.IDENTITY;
-import static tec.units.ri.AbstractQuantity.NONE;
-import static tec.units.ri.AbstractUnit.ONE;
-import static tec.units.ri.unit.Units.SECOND;
+import static tec.uom.se.AbstractConverter.IDENTITY;
+import static tec.uom.se.AbstractQuantity.NONE;
+import static tec.uom.se.AbstractUnit.ONE;
+import static tec.uom.se.unit.Units.SECOND;
 
 import javax.measure.quantity.Dimensionless;
 import javax.measure.Unit;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMetricInfoV2Test.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMetricInfoV2Test.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
-import static tec.units.ri.unit.Units.HOUR;
+import static tec.uom.se.unit.Units.HOUR;
 
 public class PcpMetricInfoV2Test {
 

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterIntegrationTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterIntegrationTest.java
@@ -10,7 +10,7 @@ import static io.pcp.parfait.dxm.MmvVersion.MMV_VERSION1;
 import static io.pcp.parfait.dxm.MmvVersion.MMV_VERSION2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 public class PcpMmvWriterIntegrationTest {
 

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 public class PcpMmvWriterTest {
 

--- a/examples/acme/src/main/java/ProductBuilder.java
+++ b/examples/acme/src/main/java/ProductBuilder.java
@@ -1,8 +1,8 @@
 import io.pcp.parfait.MonitoredCounter;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static tec.units.ri.unit.MetricPrefix.MILLI;
-import static tec.units.ri.unit.Units.SECOND;
+import static tec.uom.se.unit.MetricPrefix.MILLI;
+import static tec.uom.se.unit.Units.SECOND;
 
 public class ProductBuilder extends Thread {
     private MonitoredCounter completed;

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
        <groupId>systems.uom</groupId>
-       <artifactId>systems-unicode</artifactId>
+       <artifactId>systems-unicode-java8</artifactId>
     </dependency>
     <dependency>
       <groupId>io.pcp.parfait</groupId>

--- a/parfait-agent/src/main/resources/units.xml
+++ b/parfait-agent/src/main/resources/units.xml
@@ -4,14 +4,14 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="secondUnit" class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean">
-        <property name="staticField" value="tec.units.ri.unit.Units.SECOND"/>
+        <property name="staticField" value="tec.uom.se.unit.Units.SECOND"/>
     </bean>
 
     <bean id="millisecondUnit" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-        <property name="staticMethod" value="tec.units.ri.unit.MetricPrefix.MILLI"/>
+        <property name="staticMethod" value="tec.uom.se.unit.MetricPrefix.MILLI"/>
         <property name="arguments">
             <bean class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean">
-                <property name="staticField" value="tec.units.ri.unit.Units.SECOND"/>
+                <property name="staticField" value="tec.uom.se.unit.Units.SECOND"/>
             </bean>
         </property>
     </bean>

--- a/parfait-core/pom.xml
+++ b/parfait-core/pom.xml
@@ -39,7 +39,7 @@
 		</dependency>
 		<dependency>
             <groupId>systems.uom</groupId>
-            <artifactId>systems-unicode</artifactId>
+            <artifactId>systems-unicode-java8</artifactId>
         </dependency>
 	</dependencies>
 </project>

--- a/parfait-core/pom.xml
+++ b/parfait-core/pom.xml
@@ -30,8 +30,8 @@
 			<artifactId>unit-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>tec.units</groupId>
-			<artifactId>unit-ri</artifactId>
+			<groupId>tec.uom</groupId>
+			<artifactId>uom-se</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>systems.uom</groupId>

--- a/parfait-core/src/main/java/io/pcp/parfait/Monitorable.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/Monitorable.java
@@ -51,7 +51,7 @@ public interface Monitorable<T> {
      * @return the JSR-363 Unit represented by the value of this Monitorable.
      *         This may be used to do comparisons and rate-conversions between
      *         metrics which do not share the same scale. Values which do not
-     *         take a unit should use {@link tec.units.ri.AbstractUnit#ONE};
+     *         take a unit should use {@link tec.uom.se.AbstractUnit#ONE};
      *         values for which no unit is sensible (e.g. String values) may
      *         return null.
      */

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredConstant.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredConstant.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 import javax.measure.Unit;
 
 /**

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredCounter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredCounter.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.concurrent.atomic.AtomicLong;
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredIntValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredIntValue.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredLongValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredLongValue.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.concurrent.atomic.AtomicLong;
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredValue.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import javax.measure.Unit;
 

--- a/parfait-core/src/main/java/io/pcp/parfait/PollingMonitoredValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/PollingMonitoredValue.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.List;
 import java.util.Timer;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/EventTimer.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/EventTimer.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 import javax.measure.Unit;
 
 import org.slf4j.Logger;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/MetricMeasurement.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/MetricMeasurement.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.timing;
 
-import tec.units.ri.AbstractQuantity;
-import tec.units.ri.quantity.NumberQuantity;
+import tec.uom.se.AbstractQuantity;
+import tec.uom.se.quantity.NumberQuantity;
 
 import com.google.common.base.Preconditions;
 

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/StandardThreadMetrics.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/StandardThreadMetrics.java
@@ -1,10 +1,10 @@
 package io.pcp.parfait.timing;
 
 import static systems.uom.unicode.CLDR.BYTE;
-import static tec.units.ri.unit.MetricPrefix.MILLI;
-import static tec.units.ri.unit.MetricPrefix.NANO;
-import static tec.units.ri.unit.Units.SECOND;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.unit.MetricPrefix.MILLI;
+import static tec.uom.se.unit.MetricPrefix.NANO;
+import static tec.uom.se.unit.Units.SECOND;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import com.google.common.collect.ImmutableList;
 import java.lang.management.ManagementFactory;

--- a/parfait-core/src/test/java/io/pcp/parfait/DummyMonitorable.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/DummyMonitorable.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import javax.measure.Unit;
 

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredConstantTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredConstantTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;
-import static tec.units.ri.unit.Units.FARAD;
+import static tec.uom.se.unit.Units.FARAD;
 
 import org.junit.Test;
 

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredIntValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredIntValueTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredLongValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredLongValueTest.java
@@ -2,7 +2,7 @@ package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/parfait-core/src/test/java/io/pcp/parfait/PollingMonitoredValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/PollingMonitoredValueTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import org.junit.Test;
 

--- a/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterBuilderTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterBuilderTest.java
@@ -2,7 +2,7 @@ package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 import static systems.uom.unicode.CLDR.BYTE;
 
 import org.junit.Before;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/LoggerSinkTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/LoggerSinkTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.timing;
 
-import static tec.units.ri.unit.Units.HERTZ;
-import static tec.units.ri.unit.MetricPrefix.MEGA;
+import static tec.uom.se.unit.Units.HERTZ;
+import static tec.uom.se.unit.MetricPrefix.MEGA;
 
 import javax.measure.Unit;
 import junit.framework.TestCase;
@@ -10,7 +10,7 @@ public class LoggerSinkTest extends TestCase {
     public void testShouldProduceExpectedMetricString() {
         MetricMeasurement measurement = getUnitMeasurement(HERTZ, 1);
         String result = new LoggerSink().buildSingleMetricResult(measurement);
-        assertEquals("dummy: own 1 Hz, total 1 Hz", result);
+        assertEquals("dummy: own 1.0 Hz, total 1.0 Hz", result);
     }
 
     public void testShouldNormalizeMetricStringToCorrectUnit() {

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricDescriptorLookup.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricDescriptorLookup.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import io.pcp.parfait.ValueSemantics;
 

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapter.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.util.Set;
 

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapter.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import javax.measure.Unit;
 import java.util.Set;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapter.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import com.codahale.metrics.Metered;
 import io.pcp.parfait.Monitorable;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapter.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import javax.measure.Unit;
 import java.util.Set;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapter.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.unit.MetricPrefix.NANO;
-import static tec.units.ri.unit.Units.SECOND;
+import static tec.uom.se.unit.MetricPrefix.NANO;
+import static tec.uom.se.unit.Units.SECOND;
 
 import com.codahale.metrics.Timer;
 import io.pcp.parfait.Monitorable;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImplTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImplTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.dropwizard;
 
-import static tec.units.ri.AbstractUnit.ONE;
-import static tec.units.ri.unit.Units.GRAY;
+import static tec.uom.se.AbstractUnit.ONE;
+import static tec.uom.se.unit.Units.GRAY;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValueTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValueTest.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterFactoryTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterFactoryTest.java
@@ -2,7 +2,7 @@ package io.pcp.parfait.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.metrics.ConsoleReporterFactory;
 import io.dropwizard.metrics.CsvReporterFactory;
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertNotNull;
 public class ParfaitReporterFactoryTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private final ConfigurationFactory<MetricsFactory> factory =
-            new ConfigurationFactory<>(MetricsFactory.class,
+    private final YamlConfigurationFactory<MetricsFactory> factory =
+            new YamlConfigurationFactory<>(MetricsFactory.class,
                     Validation.buildDefaultValidatorFactory().getValidator(),
                     objectMapper, "dw");
 

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapterTest.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapterTest.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import com.codahale.metrics.Metered;
 import io.pcp.parfait.Monitorable;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapterTest.java
@@ -1,7 +1,7 @@
 package io.pcp.parfait.dropwizard.metricadapters;
 
-import static tec.units.ri.unit.MetricPrefix.NANO;
-import static tec.units.ri.unit.Units.SECOND;
+import static tec.uom.se.unit.MetricPrefix.NANO;
+import static tec.uom.se.unit.Units.SECOND;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;

--- a/parfait-dropwizard/src/test/resources/io/pcp/parfait/dropwizard/metric-app.yml
+++ b/parfait-dropwizard/src/test/resources/io/pcp/parfait/dropwizard/metric-app.yml
@@ -8,8 +8,6 @@ reporters:
     frequency: 10s
     includes:
      - io.dropwizard
-    excludes:
-     -
     replacements:
       "org.eclipse.jetty.util.thread.": ""
       "io.dropwizard.jetty.MutableServletContextHandler": "MSCH"

--- a/parfait-jdbc/src/main/java/io/pcp/parfait/jdbc/ParfaitDataSource.java
+++ b/parfait-jdbc/src/main/java/io/pcp/parfait/jdbc/ParfaitDataSource.java
@@ -1,8 +1,8 @@
 package io.pcp.parfait.jdbc;
 
-import static tec.units.ri.unit.MetricPrefix.MILLI;
-import static tec.units.ri.unit.Units.SECOND;
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.unit.MetricPrefix.MILLI;
+import static tec.uom.se.unit.Units.SECOND;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationHandler;

--- a/parfait-jmx/src/main/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactory.java
+++ b/parfait-jmx/src/main/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactory.java
@@ -1,6 +1,6 @@
 package io.pcp.parfait.jmx;
 
-import static tec.units.ri.AbstractUnit.ONE;
+import static tec.uom.se.AbstractUnit.ONE;
 
 import java.io.IOException;
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <java.major.target.version>${jdk.version}</java.major.target.version>
     <metrics3.version>0.7.1</metrics3.version>
     <unit.version>1.0</unit.version>
-    <unit.ri.version>1.0</unit.ri.version>
+    <unit.se.version>1.0.1</unit.se.version>
     <unit.systems.version>0.5</unit.systems.version>
   </properties>
 
@@ -249,9 +249,9 @@
             <version>${unit.version}</version>
           </dependency>
           <dependency>
-            <groupId>tec.units</groupId>
-            <artifactId>unit-ri</artifactId>
-            <version>${unit.ri.version}</version>
+            <groupId>tec.uom</groupId>
+            <artifactId>uom-se</artifactId>
+            <version>${unit.se.version}</version>
           </dependency>
           <dependency>
             <groupId>systems.uom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
           </dependency>
           <dependency>
             <groupId>systems.uom</groupId>
-            <artifactId>systems-unicode</artifactId>
+            <artifactId>systems-unicode-java8</artifactId>
             <version>${unit.systems.version}</version>
           </dependency>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <spring.version>4.2.5.RELEASE</spring.version>
     <slf4j.version>1.6.1</slf4j.version>
     <log4j.version>1.2.14</log4j.version>
-    <jdk.version>1.7</jdk.version>
+    <jdk.version>1.8</jdk.version>
     <project.build.javaVersion>${jdk.version}</project.build.javaVersion>
     <maven.compile.targetLevel>${jdk.version}</maven.compile.targetLevel>
     <maven.compile.sourceLevel>${jdk.version}</maven.compile.sourceLevel>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>4.2.5.RELEASE</spring.version>
     <slf4j.version>1.6.1</slf4j.version>
     <log4j.version>1.2.14</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.compile.sourceLevel>${jdk.version}</maven.compile.sourceLevel>
     <java.major.source.version>${jdk.version}</java.major.source.version>
     <java.major.target.version>${jdk.version}</java.major.target.version>
-    <metrics3.version>0.7.1</metrics3.version>
+    <metrics3.version>1.0.2</metrics3.version>
     <unit.version>1.0</unit.version>
     <unit.se.version>1.0.1</unit.se.version>
     <unit.systems.version>0.5</unit.systems.version>


### PR DESCRIPTION
Allows updating the dropwizard metrics module and replacing unit-ri with uom-se.