### PR TITLE
Update Copyright headers with maven-plugin-license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2009, Aconex
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.pcp.parfait</groupId>

--- a/dxm/src/main/java/io/pcp/parfait/dxm/ByteBufferFactory.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/ByteBufferFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.io.IOException;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/ErrorThrowingIdentifierSource.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/ErrorThrowingIdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Set;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/FileByteBufferFactory.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/FileByteBufferFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/FileParsingIdentifierSourceSet.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/FileParsingIdentifierSourceSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.io.File;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/FixedValueIdentifierSource.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/FixedValueIdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.HashSet;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/HashingIdentifierSource.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/HashingIdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Set;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/IdentifierSource.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/IdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Set;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/IdentifierSourceSet.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/IdentifierSourceSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 public interface IdentifierSourceSet {

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InMemoryByteBufferFactory.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InMemoryByteBufferFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.io.IOException;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/Instance.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/Instance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  *
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceDomain.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceDomain.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactory.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactoryV1.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactoryV1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.InstanceV1.InstanceStoreV1;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactoryV2.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceStoreFactoryV2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.InstanceV2.InstanceStoreV2;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceV1.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceV1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/InstanceV2.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/InstanceV2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/MetricName.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/MetricName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.regex.Matcher;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/MetricNameValidator.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/MetricNameValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import static io.pcp.parfait.dxm.PcpMmvWriter.PCP_CHARSET;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/MmvVersion.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/MmvVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/MmvWritable.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/MmvWritable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.nio.ByteBuffer;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpConfig.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.io.File;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpId.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpId.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfo.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.semantics.Semantics;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfoV1.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfoV1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfoV2.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMetricInfoV2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import static com.google.common.collect.Maps.newConcurrentMap;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpOffset.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpOffset.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpString.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpString.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpValueInfo.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpValueInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.semantics.Semantics;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/StringParsingIdentifierSourceSet.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/StringParsingIdentifierSourceSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Map;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/WarningIdentifierSource.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/WarningIdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Set;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/ioutils/StringIterable.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/ioutils/StringIterable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.ioutils;
 
 import java.io.File;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/Dimension.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/Dimension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpDimensionSet.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpDimensionSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpScale.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/PcpScale.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.semantics;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/Semantics.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/Semantics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.semantics;
 
 public enum Semantics {

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.semantics;
 
 import static systems.uom.unicode.CLDR.BIT;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitValued.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitValued.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/dxm/src/main/java/io/pcp/parfait/dxm/types/AbstractTypeHandler.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/types/AbstractTypeHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.types;
 
 

--- a/dxm/src/main/java/io/pcp/parfait/dxm/types/DefaultTypeHandlers.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/types/DefaultTypeHandlers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.types;
 
 import java.nio.ByteBuffer;

--- a/dxm/src/main/java/io/pcp/parfait/dxm/types/MmvMetricType.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/types/MmvMetricType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.types;
 
 

--- a/dxm/src/main/java/io/pcp/parfait/dxm/types/TypeHandler.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/types/TypeHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.types;
 
 import java.nio.ByteBuffer;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/ConstantIdentifierSource.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/ConstantIdentifierSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Set;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/ErrorThrowingIdentifierSourceTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/ErrorThrowingIdentifierSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import java.util.Collections;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/FileParsingIdentifierSourceSetTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/FileParsingIdentifierSourceSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import static io.pcp.parfait.dxm.StringParsingIdentifierSourceSetTest.FIXED_FALLBACK;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/FixedValueIdentifierSourceTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/FixedValueIdentifierSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import static org.junit.Assert.assertEquals;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/HashingIdentifierSourceTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/HashingIdentifierSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import com.google.common.collect.Sets;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/InstanceDomainTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/InstanceDomainTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/InstanceStoreFactoryV1Test.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/InstanceStoreFactoryV1Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.InstanceV1.InstanceStoreV1;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/InstanceStoreFactoryV2Test.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/InstanceStoreFactoryV2Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/InstanceV2Test.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/InstanceV2Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpString.PcpStringStore;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/Matchers.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/Matchers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import org.hamcrest.Description;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/MetricNameTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/MetricNameTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import org.junit.Test;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/MetricNameValidatorTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/MetricNameValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 

--- a/dxm/src/test/java/io/pcp/parfait/dxm/MmvVersionTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/MmvVersionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.InstanceDomain.InstanceDomainStore;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpClient.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import org.apache.commons.io.IOUtils;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMetricInfoV2Test.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMetricInfoV2Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMetricInfoV2.MetricInfoStoreV2;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterIntegrationTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.semantics.Semantics;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpMmvWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpMmvWriter.Store;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/PcpStringTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/PcpStringTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import io.pcp.parfait.dxm.PcpString.PcpStringStore;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/StringParsingIdentifierSourceSetTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/StringParsingIdentifierSourceSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm;
 
 import static org.junit.Assert.assertEquals;

--- a/examples/acme/pom.xml
+++ b/examples/acme/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/examples/acme/src/main/java/Acme.java
+++ b/examples/acme/src/main/java/Acme.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 
 public class Acme {
     private ProductBuilder rockets = new ProductBuilder("Rockets");

--- a/examples/acme/src/main/java/Main.java
+++ b/examples/acme/src/main/java/Main.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 
 public class Main {
     public static void main(String args[]) {

--- a/examples/acme/src/main/java/ProductBuilder.java
+++ b/examples/acme/src/main/java/ProductBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import io.pcp.parfait.MonitoredCounter;
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/examples/acme/src/test/java/AcmeTest.java
+++ b/examples/acme/src/test/java/AcmeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 

--- a/examples/counter/pom.xml
+++ b/examples/counter/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/examples/counter/src/main/java/Counter.java
+++ b/examples/counter/src/main/java/Counter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import io.pcp.parfait.MonitoredCounter;
 
 public class Counter implements Runnable {

--- a/examples/counter/src/main/java/Main.java
+++ b/examples/counter/src/main/java/Main.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 public class Main {
     public static void main (String args[]) {
         Thread t = new Thread(new Counter());

--- a/examples/counter/src/test/java/CounterTest.java
+++ b/examples/counter/src/test/java/CounterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/examples/sleep/pom.xml
+++ b/examples/sleep/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/examples/sleep/src/main/java/Main.java
+++ b/examples/sleep/src/main/java/Main.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 public class Main {
     public static void main (String args[]) {
         Thread t = new Thread(new Sleep());

--- a/examples/sleep/src/main/java/Sleep.java
+++ b/examples/sleep/src/main/java/Sleep.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 public class Sleep implements Runnable {
     public void run() {
         try {

--- a/examples/sleep/src/test/java/SleepTest.java
+++ b/examples/sleep/src/test/java/SleepTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 

--- a/license/#header.txt#
+++ b/license/#header.txt#
@@ -1,0 +1,14 @@
+
+Copyright 2009-2017 
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.  See the License for the specific language governing
+permissions and limitations under the License.

--- a/license/header.txt
+++ b/license/header.txt
@@ -1,0 +1,14 @@
+Copyright 2009-2017 Aconex
+
+Licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.  See the License for the specific language governing
+permissions and limitations under the License.
+

--- a/license/header.txt~
+++ b/license/header.txt~
@@ -1,0 +1,16 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/license/parfait-java.xml
+++ b/license/parfait-java.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+<additionalHeaders>
+    <parfait_java_style>
+        <firstLine>/*</firstLine>
+        <beforeEachLine> * </beforeEachLine>
+        <endLine> */EOL</endLine>
+        <afterEachLine>EOL</afterEachLine>
+        <!--skipLine></skipLine-->
+        <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </parfait_java_style>
+</additionalHeaders>

--- a/parfait-agent/license/header.txt
+++ b/parfait-agent/license/header.txt
@@ -1,0 +1,14 @@
+Copyright 2009-2017 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.  See the License for the specific language governing
+permissions and limitations under the License.
+

--- a/parfait-agent/license/header.txt~
+++ b/parfait-agent/license/header.txt~
@@ -1,0 +1,14 @@
+Copyright 2009-2017 Aconex
+
+Licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.  See the License for the specific language governing
+permissions and limitations under the License.
+

--- a/parfait-agent/license/parfait-agent-java.xml
+++ b/parfait-agent/license/parfait-agent-java.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+<additionalHeaders>
+    <parfait_java_style>
+        <firstLine>/*</firstLine>
+        <beforeEachLine> * </beforeEachLine>
+        <endLine> */EOL</endLine>
+        <afterEachLine>EOL</afterEachLine>
+        <!--skipLine></skipLine-->
+        <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </parfait_java_style>
+</additionalHeaders>

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -52,6 +69,42 @@
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+	<groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.6</version>
+        <inherited>false</inherited>
+        <configuration>
+          <skip>${license.skip}</skip>
+          <headerDefinitions>
+            <headerDefinition>license/parfait-agent-java.xml</headerDefinition>
+          </headerDefinitions>
+          <aggregate>true</aggregate>
+          <mapping>
+            <java>PARFAIT_JAVA_STYLE</java>
+          </mapping>
+          <header>license/header.txt</header>
+          <properties>
+            <inceptionYear>${project.inceptionYear}</inceptionYear>
+          </properties>
+          <includes>
+            <include>**/*.java</include>
+            <include>**/*.xml</include>
+          </includes>
+          <excludes>
+            <exclude>**/src/test/resources/**</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-license</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>check</goal>
             </goals>
           </execution>
         </executions>

--- a/parfait-agent/src/main/java/io/pcp/parfait/MonitoringViewProperties.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/MonitoringViewProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.lang.management.ManagementFactory;

--- a/parfait-agent/src/main/java/io/pcp/parfait/OptionalMonitoredMBeanRegistrar.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/OptionalMonitoredMBeanRegistrar.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import javax.management.AttributeNotFoundException;

--- a/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import io.pcp.parfait.DynamicMonitoringView;

--- a/parfait-agent/src/main/resources/agent.xml
+++ b/parfait-agent/src/main/resources/agent.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/parfait-agent/src/main/resources/dropwizard.xml
+++ b/parfait-agent/src/main/resources/dropwizard.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/parfait-agent/src/main/resources/jdbc.xml
+++ b/parfait-agent/src/main/resources/jdbc.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/parfait-agent/src/main/resources/local.xml
+++ b/parfait-agent/src/main/resources/local.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans profile="local"
        xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/parfait-agent/src/main/resources/log4j2.xml
+++ b/parfait-agent/src/main/resources/log4j2.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <Configuration package="io.pcp.parfait" status="WARN">
 <Appenders>
     <Console name="Console" target="SYSTEM_OUT">

--- a/parfait-agent/src/main/resources/mbeans.xml
+++ b/parfait-agent/src/main/resources/mbeans.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/parfait-agent/src/main/resources/proxy.xml
+++ b/parfait-agent/src/main/resources/proxy.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans profile="proxy"
        xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/parfait-agent/src/main/resources/units.xml
+++ b/parfait-agent/src/main/resources/units.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2009-2017 Red Hat Inc.
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/parfait-agent/src/test/java/io/pcp/parfait/MonitoringViewNamesTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/MonitoringViewNamesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-agent/src/test/java/io/pcp/parfait/MonitoringViewPropertiesTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/MonitoringViewPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.After;

--- a/parfait-agent/src/test/java/io/pcp/parfait/ParfaitAgentArgumentsTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/ParfaitAgentArgumentsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.After;

--- a/parfait-agent/src/test/java/io/pcp/parfait/ParfaitAgentSpringTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/ParfaitAgentSpringTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Test;

--- a/parfait-benchmark/pom.xml
+++ b/parfait-benchmark/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.pcp.parfait</groupId>

--- a/parfait-benchmark/src/main/assembly/appassembler.xml
+++ b/parfait-benchmark/src/main/assembly/appassembler.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <assembly>
     <id>bin</id>
     <formats>

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/BlockedMetricCollector.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/BlockedMetricCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import java.lang.management.ManagementFactory;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/BlockedMetricHelper.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/BlockedMetricHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import java.util.List;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTest.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import static io.pcp.parfait.benchmark.BlockedMetricHelper.computeTotalBlockedCount;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTestRunner.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTestRunner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import java.lang.management.ManagementFactory;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CounterIncrementer.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CounterIncrementer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import java.lang.management.ManagementFactory;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/ReportHelper.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/ReportHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import static java.net.InetAddress.getLocalHost;

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/StandardMetricThroughPutBenchmark.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/StandardMetricThroughPutBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.benchmark;
 
 import static io.pcp.parfait.benchmark.BlockedMetricHelper.computeTotalBlockedCount;

--- a/parfait-core/pom.xml
+++ b/parfait-core/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.pcp.parfait</groupId>

--- a/parfait-core/src/main/java/io/pcp/parfait/AbstractMonitorable.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/AbstractMonitorable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.List;

--- a/parfait-core/src/main/java/io/pcp/parfait/CompositeCounter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/CompositeCounter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/CompositeMonitoringView.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/CompositeMonitoringView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import com.google.common.base.Predicate;

--- a/parfait-core/src/main/java/io/pcp/parfait/Counter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/Counter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 public interface Counter {

--- a/parfait-core/src/main/java/io/pcp/parfait/DynamicMonitoringView.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/DynamicMonitoringView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import com.google.common.collect.Lists;

--- a/parfait-core/src/main/java/io/pcp/parfait/Monitor.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/Monitor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 /**

--- a/parfait-core/src/main/java/io/pcp/parfait/Monitorable.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/Monitorable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitorableRegistry.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitorableRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitorableRegistryListener.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitorableRegistryListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 public interface MonitorableRegistryListener {

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredConstant.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredConstant.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredCounter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredCounter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredIntValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredIntValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredLongValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredLongValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredNumeric.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredNumeric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoredValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoredValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/MonitoringView.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/MonitoringView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/PollingMonitoredValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/PollingMonitoredValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Timer;

--- a/parfait-core/src/main/java/io/pcp/parfait/Scheduler.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/Scheduler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.TimerTask;

--- a/parfait-core/src/main/java/io/pcp/parfait/SettableValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/SettableValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/SystemTimePoller.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/SystemTimePoller.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import com.google.common.base.Supplier;

--- a/parfait-core/src/main/java/io/pcp/parfait/TimeWindow.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/TimeWindow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import net.jcip.annotations.ThreadSafe;

--- a/parfait-core/src/main/java/io/pcp/parfait/TimeWindowCounter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/TimeWindowCounter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Arrays;

--- a/parfait-core/src/main/java/io/pcp/parfait/TimeWindowCounterBuilder.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/TimeWindowCounterBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.List;

--- a/parfait-core/src/main/java/io/pcp/parfait/TimerScheduler.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/TimerScheduler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Timer;

--- a/parfait-core/src/main/java/io/pcp/parfait/ValueSemantics.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/ValueSemantics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 /**

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/AbstractThreadMetric.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/AbstractThreadMetric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/CounterPair.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/CounterPair.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import io.pcp.parfait.Counter;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/CounterPairFactory.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/CounterPairFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import io.pcp.parfait.*;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/DummyEventTimer.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/DummyEventTimer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collections;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/EventCounters.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/EventCounters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  *
  */

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/EventMetricCollector.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/EventMetricCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.ArrayDeque;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/EventMetricCounters.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/EventMetricCounters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import io.pcp.parfait.MonitoredCounter;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/EventTimer.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/EventTimer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.lang.management.ManagementFactory;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/InProgressExporter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/InProgressExporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/InProgressSnapshot.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/InProgressSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.ArrayList;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/LoggerSink.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/LoggerSink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/MetricMeasurement.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/MetricMeasurement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import tec.uom.se.AbstractQuantity;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/SamplingMeasurementSink.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/SamplingMeasurementSink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 /**

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/StandardThreadMetrics.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/StandardThreadMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import static systems.uom.unicode.CLDR.BYTE;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/StepMeasurementSink.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/StepMeasurementSink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 /**

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/StepMeasurements.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/StepMeasurements.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.ArrayList;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadContext.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadCounter.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadCounter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadMetric.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadMetric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadMetricSuite.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadMetricSuite.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collection;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValue.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collections;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValueMetric.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadValueMetric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import javax.measure.Unit;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/Timeable.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/Timeable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 

--- a/parfait-core/src/test/java/io/pcp/parfait/CompositeCounterTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/CompositeCounterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Arrays;

--- a/parfait-core/src/test/java/io/pcp/parfait/CompositeMonitoringViewTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/CompositeMonitoringViewTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Before;

--- a/parfait-core/src/test/java/io/pcp/parfait/DummyMonitorable.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/DummyMonitorable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-core/src/test/java/io/pcp/parfait/DynamicMonitoringViewTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/DynamicMonitoringViewTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Before;

--- a/parfait-core/src/test/java/io/pcp/parfait/ManualScheduler.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/ManualScheduler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import java.util.Map;

--- a/parfait-core/src/test/java/io/pcp/parfait/ManualTimeSupplier.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/ManualTimeSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import com.google.common.base.Supplier;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitorableRegistryTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitorableRegistryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Test;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredConstantTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredConstantTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredCounterTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredCounterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Test;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredIntValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredIntValueTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/MonitoredLongValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/MonitoredLongValueTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/PollingMonitoredValueTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/PollingMonitoredValueTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/QuiescentRegistryListenerTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/QuiescentRegistryListenerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import org.junit.Test;

--- a/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterBuilderTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterBuilderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/TimeWindowCounterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/TimeWindowTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/TimeWindowTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/DummyThreadMetric.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/DummyThreadMetric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/EventMetricCollectorTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/EventMetricCollectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import static com.google.common.collect.Lists.newArrayList;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/EventTimerTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/EventTimerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collections;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/LoggerSinkTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/LoggerSinkTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import static tec.uom.se.unit.Units.HERTZ;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/MetricMeasurementTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/MetricMeasurementTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import junit.framework.TestCase;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/SampleRun.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/SampleRun.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Collections;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/SamplingMeasurementSinkTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/SamplingMeasurementSinkTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import org.junit.Test;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/StepMeasurementsTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/StepMeasurementsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import junit.framework.TestCase;

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/ThreadContextTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/ThreadContextTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.timing;
 
 import java.util.Hashtable;

--- a/parfait-cxf/pom.xml
+++ b/parfait-cxf/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>parfait</artifactId>

--- a/parfait-cxf/src/main/java/io/pcp/parfait/cxf/MonitoringInterceptor.java
+++ b/parfait-cxf/src/main/java/io/pcp/parfait/cxf/MonitoringInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.cxf;
 
 import org.apache.cxf.interceptor.Fault;

--- a/parfait-cxf/src/main/java/io/pcp/parfait/cxf/X.java
+++ b/parfait-cxf/src/main/java/io/pcp/parfait/cxf/X.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.cxf;
 
 public class X {

--- a/parfait-cxf/src/test/java/io/pcp/parfait/cxf/ParfaitIntegrationTest.java
+++ b/parfait-cxf/src/test/java/io/pcp/parfait/cxf/ParfaitIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.cxf;
 
 import static org.junit.Assert.assertNotNull;

--- a/parfait-cxf/src/test/java/io/pcp/parfait/cxf/RestDemo.java
+++ b/parfait-cxf/src/test/java/io/pcp/parfait/cxf/RestDemo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.cxf;
 
 import javax.ws.rs.GET;

--- a/parfait-cxf/src/test/java/io/pcp/parfait/cxf/SpringCreatedTestServer.java
+++ b/parfait-cxf/src/test/java/io/pcp/parfait/cxf/SpringCreatedTestServer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.cxf;
 
 import java.net.URISyntaxException;

--- a/parfait-dropwizard/pom.xml
+++ b/parfait-dropwizard/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricDescriptorLookup.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricDescriptorLookup.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricNameTranslator.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/DefaultMetricNameTranslator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import java.util.LinkedHashMap;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import java.util.Set;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapterFactory.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapterFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import com.codahale.metrics.Metric;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImpl.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import com.codahale.metrics.Counter;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricDescriptor.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricDescriptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import javax.measure.Unit;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricDescriptorLookup.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricDescriptorLookup.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 /**

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricNameTranslator.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/MetricNameTranslator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 /**

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValue.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import javax.measure.Unit;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/ParfaitReporter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/ParfaitReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import static com.codahale.metrics.MetricRegistry.name;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/ParfaitReporterFactory.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/ParfaitReporterFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import javax.measure.Unit;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static com.codahale.metrics.MetricRegistry.name;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static com.codahale.metrics.MetricRegistry.name;

--- a/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapter.java
+++ b/parfait-dropwizard/src/main/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.unit.MetricPrefix.NANO;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImplTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/MetricAdapterFactoryImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValueTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/NonSelfRegisteringSettableValueTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterFactoryTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/ParfaitReporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard;
 
 

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/CountingAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/GaugeAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/HistogramAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static org.hamcrest.Matchers.is;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/MeteredAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/SamplingAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static org.hamcrest.Matchers.is;

--- a/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapterTest.java
+++ b/parfait-dropwizard/src/test/java/io/pcp/parfait/dropwizard/metricadapters/TimerAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dropwizard.metricadapters;
 
 import static tec.uom.se.unit.MetricPrefix.NANO;

--- a/parfait-io/pom.xml
+++ b/parfait-io/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>

--- a/parfait-io/src/main/java/io/pcp/parfait/io/ByteCountingInputStream.java
+++ b/parfait-io/src/main/java/io/pcp/parfait/io/ByteCountingInputStream.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.io;
 
 import io.pcp.parfait.Counter;

--- a/parfait-io/src/main/java/io/pcp/parfait/io/ByteCountingOutputStream.java
+++ b/parfait-io/src/main/java/io/pcp/parfait/io/ByteCountingOutputStream.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.io;
 
 import io.pcp.parfait.Counter;

--- a/parfait-io/src/test/java/io/pcp/parfait/io/ByteCountingInputStreamTest.java
+++ b/parfait-io/src/test/java/io/pcp/parfait/io/ByteCountingInputStreamTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.io;
 
 import java.io.ByteArrayInputStream;

--- a/parfait-io/src/test/java/io/pcp/parfait/io/ByteCountingOutputStreamTest.java
+++ b/parfait-io/src/test/java/io/pcp/parfait/io/ByteCountingOutputStreamTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.io;
 
 import java.io.ByteArrayOutputStream;

--- a/parfait-jdbc/pom.xml
+++ b/parfait-jdbc/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>

--- a/parfait-jdbc/src/main/java/io/pcp/parfait/jdbc/ParfaitDataSource.java
+++ b/parfait-jdbc/src/main/java/io/pcp/parfait/jdbc/ParfaitDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jdbc;
 
 import static tec.uom.se.unit.MetricPrefix.MILLI;

--- a/parfait-jdbc/src/test/java/io/pcp/parfait/jdbc/ParfaitDataSourceTest.java
+++ b/parfait-jdbc/src/test/java/io/pcp/parfait/jdbc/ParfaitDataSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jdbc;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-jmx/pom.xml
+++ b/parfait-jmx/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>

--- a/parfait-jmx/src/main/java/io/pcp/parfait/jmx/JmxInProgressMonitor.java
+++ b/parfait-jmx/src/main/java/io/pcp/parfait/jmx/JmxInProgressMonitor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import java.util.List;

--- a/parfait-jmx/src/main/java/io/pcp/parfait/jmx/JmxView.java
+++ b/parfait-jmx/src/main/java/io/pcp/parfait/jmx/JmxView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import io.pcp.parfait.Monitor;

--- a/parfait-jmx/src/main/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactory.java
+++ b/parfait-jmx/src/main/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import static tec.uom.se.AbstractUnit.ONE;

--- a/parfait-jmx/src/test/java/io/pcp/parfait/jmx/JmxInProgressMonitorTest.java
+++ b/parfait-jmx/src/test/java/io/pcp/parfait/jmx/JmxInProgressMonitorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import static org.junit.Assert.assertEquals;

--- a/parfait-jmx/src/test/java/io/pcp/parfait/jmx/JmxViewTest.java
+++ b/parfait-jmx/src/test/java/io/pcp/parfait/jmx/JmxViewTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import io.pcp.parfait.MonitorableRegistry;

--- a/parfait-jmx/src/test/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactoryTest.java
+++ b/parfait-jmx/src/test/java/io/pcp/parfait/jmx/MonitoredMBeanAttributeFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.jmx;
 
 import junit.framework.TestCase;

--- a/parfait-pcp/pom.xml
+++ b/parfait-pcp/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/EmptyTextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/EmptyTextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * 
  */

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/FileParsingTextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/FileParsingTextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import java.io.File;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MapTextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MapTextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import java.util.Map;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MetricDescriptionTextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MetricDescriptionTextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import io.pcp.parfait.Monitorable;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MetricNameMapper.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/MetricNameMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import io.pcp.parfait.dxm.MetricName;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/PcpMonitorBridge.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/PcpMonitorBridge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import io.pcp.parfait.Monitor;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/RegexSequenceNameMapper.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/RegexSequenceNameMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import java.util.ArrayList;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/StringParsingTextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/StringParsingTextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import java.util.Map;

--- a/parfait-pcp/src/main/java/io/pcp/parfait/pcp/TextSource.java
+++ b/parfait-pcp/src/main/java/io/pcp/parfait/pcp/TextSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import io.pcp.parfait.Monitorable;

--- a/parfait-pcp/src/main/test/java/io.pcp.parfait.pcp/PcpMonitorBridgeIntegrationTest.java
+++ b/parfait-pcp/src/main/test/java/io.pcp.parfait.pcp/PcpMonitorBridgeIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.pcp;
 
 import io.pcp.parfait.DummyMonitorable;

--- a/parfait-spring/pom.xml
+++ b/parfait-spring/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <artifactId>parfait</artifactId>

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/AdviceNotifier.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/AdviceNotifier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import org.slf4j.Logger;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/AdvisedAware.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/AdvisedAware.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 public interface AdvisedAware {

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/MonitoringAspect.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/MonitoringAspect.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import java.util.Map;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/Profiled.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/Profiled.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import java.lang.annotation.*;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/SelfStartingMonitoringView.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/SelfStartingMonitoringView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import io.pcp.parfait.DynamicMonitoringView;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/BeanPredicates.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/BeanPredicates.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring.timing;
 
 import com.google.common.base.Predicate;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/BeanSpecification.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/BeanSpecification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring.timing;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;

--- a/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/SpringEventTimerInjector.java
+++ b/parfait-spring/src/main/java/io/pcp/parfait/spring/timing/SpringEventTimerInjector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring.timing;
 
 import org.springframework.beans.BeansException;

--- a/parfait-spring/src/test/java/io/pcp/parfait/spring/DelayingBean.java
+++ b/parfait-spring/src/test/java/io/pcp/parfait/spring/DelayingBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import java.util.Random;

--- a/parfait-spring/src/test/java/io/pcp/parfait/spring/MonitorTest.java
+++ b/parfait-spring/src/test/java/io/pcp/parfait/spring/MonitorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import io.pcp.parfait.Monitorable;

--- a/parfait-spring/src/test/java/io/pcp/parfait/spring/SelfStartingMonitoringViewTest.java
+++ b/parfait-spring/src/test/java/io/pcp/parfait/spring/SelfStartingMonitoringViewTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring;
 
 import io.pcp.parfait.DynamicMonitoringView;

--- a/parfait-spring/src/test/java/io/pcp/parfait/spring/timing/BeanPredicatesTest.java
+++ b/parfait-spring/src/test/java/io/pcp/parfait/spring/timing/BeanPredicatesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.spring.timing;
 
 import static org.junit.Assert.assertFalse;

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2009-2017 Aconex
+
+    Licensed under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -171,6 +188,44 @@
                     </execution>
                 </executions>
             </plugin>
+	    <plugin>
+	      <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin</artifactId>
+              <version>2.6</version>
+              <inherited>false</inherited>
+              <configuration>
+                <skip>${license.skip}</skip>
+                <headerDefinitions>
+                  <headerDefinition>license/parfait-java.xml</headerDefinition>
+                </headerDefinitions>
+                <aggregate>true</aggregate>
+                <mapping>
+                  <java>PARFAIT_JAVA_STYLE</java>
+                </mapping>
+                <header>license/header.txt</header>
+                <properties>
+                  <inceptionYear>${project.inceptionYear}</inceptionYear>
+                </properties>
+                <includes>
+                  <include>**/*.java</include>
+                  <include>**/*.xml</include>
+                </includes>
+                <excludes>
+                  <exclude>**/src/test/resources/**</exclude>
+		  <exclude>parfait-agent/**</exclude>
+		  <exclude>bin/**</exclude>
+                </excludes>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>check-license</id>
+                  <phase>initialize</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </execution>
+              </executions>
+	    </plugin>
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
Add proper copyright headers (aconex, red hat for parfait-agent), for
inclusion into the Fedora project.  Done via maven-plugin-license and
verified in check