### PR TITLE
Parfait agent uom parsing

### DIFF
--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
-      <version>3.4.3</version>
+      <version>${unitils.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dxm/src/test/java/io/pcp/parfait/dxm/Matchers.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/Matchers.java
@@ -27,7 +27,7 @@ import static org.unitils.reflectionassert.ReflectionComparatorFactory.createRef
 
 public class Matchers {
 
-    static class ReflectiveMatcher extends TypeSafeMatcher<Object> {
+    public static class ReflectiveMatcher extends TypeSafeMatcher<Object> {
 
         private final Object expected;
         private Difference difference;
@@ -50,7 +50,7 @@ public class Matchers {
             }
         }
 
-        static ReflectiveMatcher reflectivelyEqualing(Object expected) {
+        public static ReflectiveMatcher reflectivelyEqualing(Object expected) {
             return new ReflectiveMatcher(expected);
         }
 

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
-      <version>3.4.3</version>
+      <version>${unitils.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -119,6 +119,19 @@
     </dependency>
     <dependency>
       <groupId>io.pcp.parfait</groupId>
+      <artifactId>dxm</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.unitils</groupId>
+      <artifactId>unitils-core</artifactId>
+      <version>3.4.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.pcp.parfait</groupId>
       <artifactId>parfait-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -160,6 +173,16 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.8.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
@@ -16,36 +16,29 @@
 
 package io.pcp.parfait;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.pcp.parfait.MonitoringViewProperties;
-import io.pcp.parfait.AgentMonitoringView;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.lang.instrument.Instrumentation;
-import java.net.ConnectException;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.management.MalformedObjectNameException;
-import javax.management.ReflectionException;
-import javax.management.MBeanServerConnection;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanException;
 import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.ReflectionException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.log4j.Logger;
 
 public class ParfaitAgent {
     private static final Logger logger = Logger.getLogger(ParfaitAgent.class);
+    private static final SpecificationAdapter specificationAdapter = new SpecificationAdapter();
 
     private static final String RESOURCE = "/jvm.json";
     private static final String PATHNAME = "/etc/parfait";
@@ -107,7 +100,7 @@ public class ParfaitAgent {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode metrics = mapper.readTree(in).path("metrics");
             for (JsonNode node : metrics) {
-                monitorables.add(new Specification(node));
+                monitorables.add(specificationAdapter.fromJson(node));
             }
         } catch (Exception e) {
             logger.error(String.format("Unexpected JSON format\n%s", e.getMessage()));

--- a/parfait-agent/src/main/java/io/pcp/parfait/Specification.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/Specification.java
@@ -16,92 +16,71 @@
 
 package io.pcp.parfait;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import systems.uom.quantity.Information;
-import tec.uom.se.unit.MetricPrefix;
-import tec.uom.se.unit.Units;
 import static tec.uom.se.AbstractUnit.ONE;
 
 import javax.measure.Unit;
 import javax.measure.quantity.Time;
 
-public class Specification {
-    public String name;
-    public boolean optional;
-    public String description;
-    public Unit<?> unit = ONE;
-    public ValueSemantics semantics = ValueSemantics.FREE_RUNNING;
-    public String mBeanName;
-    public String mBeanAttributeName;
-    public String mBeanCompositeDataItem;
-    
-    public Specification() {
-    }
+import systems.uom.quantity.Information;
+import tec.uom.se.unit.MetricPrefix;
+import tec.uom.se.unit.Units;
 
-    private Specification(String name, boolean optional, String description,
+class Specification {
+    private final String name;
+    private final boolean optional;
+    private final String description;
+    private final Unit<?> unit;
+    private final ValueSemantics semantics;
+    private final String mBeanName;
+    private final String mBeanAttributeName;
+    private final String mBeanCompositeDataItem;
+
+    Specification(String name, boolean optional, String description,
                 String semantics, String units, String mBeanName,
                 String mBeanAttributeName, String mBeanCompositeDataItem) {
         this.name = name;
         this.optional = optional;
         this.description = description;
         this.mBeanName = mBeanName;
-        if (!units.isEmpty())
-            this.unit = parseUnits(name, units);
-        if (!semantics.isEmpty())
-            this.semantics = parseSemantics(name, semantics);
-        if (!mBeanAttributeName.isEmpty())
-            this.mBeanAttributeName = mBeanAttributeName;
-        if (!mBeanCompositeDataItem.isEmpty())
-            this.mBeanCompositeDataItem = mBeanCompositeDataItem;
+        this.unit = parseUnits(name, units);
+        this.semantics = parseSemantics(name, semantics);
+        this.mBeanAttributeName = mBeanAttributeName;
+        this.mBeanCompositeDataItem = mBeanCompositeDataItem;
     }
 
-    public Specification(JsonNode node) {
-        this(node.path("name").asText(),
-             node.path("optional").asBoolean(),
-             node.path("description").asText(),
-             node.path("semantics").asText(),
-             node.path("units").asText(),
-             node.path("mBeanName").asText(),
-             node.path("mBeanAttributeName").asText(),
-             node.path("mBeanCompositeDataItem").asText());
-    }
-
-    public ValueSemantics getSemantics() {
+    ValueSemantics getSemantics() {
         return semantics;
     }
 
-    public String getName() {
+    String getName() {
         return name;
     }
 
-    public boolean getOptional() {
+    boolean getOptional() {
         return optional;
     }
 
-    public String getDescription() {
+    String getDescription() {
         return description;
     }
 
-    public Unit<?> getUnits() {
+    Unit<?> getUnits() {
         return unit;
     }
 
-    public String getMBeanName() {
+    String getMBeanName() {
         return mBeanName;
     }
 
-    public String getMBeanAttributeName() {
+    String getMBeanAttributeName() {
         return mBeanAttributeName;
     }
 
-    public String getMBeanCompositeDataItem() {
+    String getMBeanCompositeDataItem() {
         return mBeanCompositeDataItem;
     }
 
-    public ValueSemantics parseSemantics(String name, String semantics) {
+    private ValueSemantics parseSemantics(String name, String semantics) {
         if (!semantics.isEmpty()) {
             if (semantics.equalsIgnoreCase("constant") ||
                 semantics.equalsIgnoreCase("discrete"))
@@ -113,13 +92,12 @@ public class Specification {
                      semantics.equalsIgnoreCase("instant") ||
                      semantics.equalsIgnoreCase("instantaneous"))
                 return ValueSemantics.FREE_RUNNING;
-            String msg = "Unexpected semantics [" + semantics + "]";
-            throw new SpecificationException(name, msg);
+            throw new SpecificationException(name, "Unexpected semantics [" + semantics + "]");
         }
         return ValueSemantics.FREE_RUNNING;
     }
 
-    public Unit<?> parseUnits(String name, String units) {
+    private Unit<?> parseUnits(String name, String units) {
         if (units.equalsIgnoreCase("milliseconds")) {
             Unit<Time> MILLISECONDS = MetricPrefix.MILLI(Units.SECOND);
             return MILLISECONDS;
@@ -133,8 +111,5 @@ public class Specification {
             throw new SpecificationException(name, msg);
         }
         return ONE;
-
-        // UoM SimpleUnitFormat?  Something else?
-        //  return [AbstractUnit].parse(units);
     }
 }

--- a/parfait-agent/src/main/java/io/pcp/parfait/Specification.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/Specification.java
@@ -16,16 +16,22 @@
 
 package io.pcp.parfait;
 
-import static tec.uom.se.AbstractUnit.ONE;
+import static systems.uom.unicode.CLDR.BYTE;
+import static tec.uom.se.unit.MetricPrefix.MILLI;
+import static tec.uom.se.unit.Units.SECOND;
 
 import javax.measure.Unit;
-import javax.measure.quantity.Time;
+import javax.measure.format.ParserException;
 
-import systems.uom.quantity.Information;
-import tec.uom.se.unit.MetricPrefix;
-import tec.uom.se.unit.Units;
+import tec.uom.se.format.SimpleUnitFormat;
 
 class Specification {
+
+    static {
+        SimpleUnitFormat.getInstance().alias(MILLI(SECOND), "milliseconds");
+        SimpleUnitFormat.getInstance().alias(BYTE, "bytes");
+    }
+
     private final String name;
     private final boolean optional;
     private final String description;
@@ -98,18 +104,10 @@ class Specification {
     }
 
     private Unit<?> parseUnits(String name, String units) {
-        if (units.equalsIgnoreCase("milliseconds")) {
-            Unit<Time> MILLISECONDS = MetricPrefix.MILLI(Units.SECOND);
-            return MILLISECONDS;
+        try {
+            return SimpleUnitFormat.getInstance().parse(units);
+        } catch (ParserException e) {
+            throw new SpecificationException("Unexpected units [" + units + "] for " + name, e);
         }
-        if (units.equalsIgnoreCase("bytes")) {
-            Unit<Information> BYTE = systems.uom.unicode.CLDR.BYTE;
-            return BYTE;
-        }
-        if (!units.isEmpty()) {
-            String msg = "Unexpected units [" + units + "]";
-            throw new SpecificationException(name, msg);
-        }
-        return ONE;
     }
 }

--- a/parfait-agent/src/main/java/io/pcp/parfait/SpecificationAdapter.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/SpecificationAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.pcp.parfait;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+class SpecificationAdapter {
+
+    Specification fromJson(JsonNode jsonNode) {
+        return new Specification(jsonNode.path("name").asText(),
+                jsonNode.path("optional").asBoolean(),
+                jsonNode.path("description").asText(),
+                jsonNode.path("semantics").asText(),
+                jsonNode.path("units").asText(),
+                jsonNode.path("mBeanName").asText(),
+                jsonNode.path("mBeanAttributeName").asText(),
+                jsonNode.path("mBeanCompositeDataItem").asText());
+
+    }
+
+}

--- a/parfait-agent/src/main/java/io/pcp/parfait/SpecificationException.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/SpecificationException.java
@@ -33,14 +33,6 @@ public class SpecificationException extends RuntimeException {
     /**
      * Constructor for SpecificationException.
      * @param msg the detail message
-     */
-    public SpecificationException(String msg) {
-        super(msg);
-    }
-
-    /**
-     * Constructor for SpecificationException.
-     * @param msg the detail message
      * @param cause the root cause (raw Java exception)
      */
     public SpecificationException(String msg, Throwable cause) {

--- a/parfait-agent/src/test/java/io/pcp/parfait/SpecificationAdapterTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/SpecificationAdapterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2009-2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.pcp.parfait;
+
+import static io.pcp.parfait.dxm.Matchers.ReflectiveMatcher.reflectivelyEqualing;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+public class SpecificationAdapterTest {
+
+    private static final String NAME = "myname";
+    private static final boolean OPTIONAL = true;
+    private static final String DESCRIPTION = "My description";
+    private static final String SEMANTICS = "";
+    private static final String UNITS = "milliseconds";
+    private static final String MBEAN_NAME = "My MBean Name";
+    private static final String MBEAN_ATTRIBUTE_NAME = "My MBean attribute name";
+    private static final String MBEAN_COMPOSITE_DATA_ITEM = "My MBean composite data item";
+    private final SpecificationAdapter specificationAdapter = new SpecificationAdapter();
+
+    @Test
+    public void fromJson_shouldConstructASpecificationFromAJsonRepresentation() {
+        JsonNode jsonNode = mock(JsonNode.class, RETURNS_DEEP_STUBS);
+
+        when(jsonNode.path("name").asText()).thenReturn(NAME);
+        when(jsonNode.path("optional").asBoolean()).thenReturn(OPTIONAL);
+        when(jsonNode.path("description").asText()).thenReturn(DESCRIPTION);
+        when(jsonNode.path("semantics").asText()).thenReturn(SEMANTICS);
+        when(jsonNode.path("units").asText()).thenReturn(UNITS);
+        when(jsonNode.path("mBeanName").asText()).thenReturn(MBEAN_NAME);
+        when(jsonNode.path("mBeanAttributeName").asText()).thenReturn(MBEAN_ATTRIBUTE_NAME);
+        when(jsonNode.path("mBeanCompositeDataItem").asText()).thenReturn(MBEAN_COMPOSITE_DATA_ITEM);
+
+        Specification actual = specificationAdapter.fromJson(jsonNode);
+        Specification expected = new Specification(NAME, OPTIONAL, DESCRIPTION, SEMANTICS, UNITS, MBEAN_NAME, MBEAN_ATTRIBUTE_NAME, MBEAN_COMPOSITE_DATA_ITEM);
+
+        assertThat(actual, is(reflectivelyEqualing(expected)));
+    }
+
+
+
+}

--- a/parfait-agent/src/test/java/io/pcp/parfait/SpecificationTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/SpecificationTest.java
@@ -18,34 +18,48 @@ package io.pcp.parfait;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static systems.uom.unicode.CLDR.BYTE;
 import static tec.uom.se.unit.MetricPrefix.MILLI;
 import static tec.uom.se.unit.Units.SECOND;
 
-import java.lang.reflect.Field;
-import javax.measure.Unit;
-import javax.measure.quantity.Time;
-
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import systems.uom.quantity.Information;
-import tec.uom.se.unit.MetricPrefix;
-import tec.uom.se.unit.Units;
 
 public class SpecificationTest {
 
     @Test
-    public void getUnits_shouldReturnMillisecondUnitsWhenASpecificationIsDefinedWithAMillisecondString() {
-        final Specification specification = new Specification("test", false, null, "", "milliseconds", null, "", "");
+    public void getUnits_shouldReturnMillisecondUnits_whenASpecificationIsDefinedWithACustomMillisecondsString() {
+        final Specification specification = specificationWithUnit("milliseconds");
 
         assertThat(specification.getUnits(), is(MILLI(SECOND)));
     }
 
     @Test
-    public void getUnits_shouldReturnByteUnitsWhenASpecificationIsDefinedWithABytesString() {
-        final Specification specification = new Specification("test", false, null, "", "bytes", null, "", "");
+    public void getUnits_shouldReturnMillisecondUnits_whenASpecificationIsDefinedWithTheUnitsOfMeasurementMsString() {
+        final Specification specification = specificationWithUnit("ms");
+
+        assertThat(specification.getUnits(), is(MILLI(SECOND)));
+    }
+
+    @Test
+    public void getUnits_shouldReturnByteUnits_whenASpecificationIsDefinedWithACustomBytesString() {
+        final Specification specification = specificationWithUnit("bytes");
 
         assertThat(specification.getUnits(), is(BYTE));
+    }
+
+    @Test
+    public void getUnits_shouldReturnByteUnits_whenASpecificationIsDefinedWithAUnitsOfMeasurementByteString() {
+        final Specification specification = specificationWithUnit("byte");
+
+        assertThat(specification.getUnits(), is(BYTE));
+    }
+
+    @Test(expected = SpecificationException.class)
+    public void new_throwsASpecificationExceptionIfTheUnitsCannotBeParsed() {
+        specificationWithUnit("not-a-unit");
+    }
+
+    private Specification specificationWithUnit(String unit) {
+        return new Specification("test", false, null, "", unit, null, "", "");
     }
 }

--- a/parfait-agent/src/test/java/io/pcp/parfait/SpecificationTest.java
+++ b/parfait-agent/src/test/java/io/pcp/parfait/SpecificationTest.java
@@ -16,11 +16,18 @@
 
 package io.pcp.parfait;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static systems.uom.unicode.CLDR.BYTE;
+import static tec.uom.se.unit.MetricPrefix.MILLI;
+import static tec.uom.se.unit.Units.SECOND;
 
 import java.lang.reflect.Field;
 import javax.measure.Unit;
 import javax.measure.quantity.Time;
+
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import systems.uom.quantity.Information;
 import tec.uom.se.unit.MetricPrefix;
@@ -28,114 +35,17 @@ import tec.uom.se.unit.Units;
 
 public class SpecificationTest {
 
-    public void testSetterOfStringField(Specification pojo, String name) throws NoSuchFieldException, IllegalAccessException {
-        final String value = "test_" + name;
-        final Field field = pojo.getClass().getDeclaredField(name);
-        field.setAccessible(true);
-        assertEquals(name + " not set", field.get(pojo), value);
+    @Test
+    public void getUnits_shouldReturnMillisecondUnitsWhenASpecificationIsDefinedWithAMillisecondString() {
+        final Specification specification = new Specification("test", false, null, "", "milliseconds", null, "", "");
+
+        assertThat(specification.getUnits(), is(MILLI(SECOND)));
     }
 
     @Test
-    public void testSettingNameField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.name = "test_name";
-        testSetterOfStringField(pojo, "name");
-    }
+    public void getUnits_shouldReturnByteUnitsWhenASpecificationIsDefinedWithABytesString() {
+        final Specification specification = new Specification("test", false, null, "", "bytes", null, "", "");
 
-    @Test
-    public void testSettingTextField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.description = "test_description";
-        testSetterOfStringField(pojo, "description");
-    }
-
-    @Test
-    public void testSettingMBeanNameField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.mBeanName = "test_mBeanName";
-        testSetterOfStringField(pojo, "mBeanName");
-    }
-
-    @Test
-    public void testSettingMBeanAttributeNameField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.mBeanAttributeName = "test_mBeanAttributeName";
-        testSetterOfStringField(pojo, "mBeanAttributeName");
-    }
-
-    @Test
-    public void testSettingMBeanCompositeDataItemField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.mBeanCompositeDataItem = "test_mBeanCompositeDataItem";
-        testSetterOfStringField(pojo, "mBeanCompositeDataItem");
-    }
-
-    @Test
-    public void testParsingUnitsTime() {
-        final Specification pojo = new Specification();
-        final Unit<Time> MILLISECONDS = MetricPrefix.MILLI(Units.SECOND);
-        Unit<?> unit = pojo.parseUnits("test", "milliseconds");
-        assertEquals("Parsing milliseconds", unit, MILLISECONDS);
-    }
-
-    @Test
-    public void testParsingUnitsInformation() {
-        final Specification pojo = new Specification();
-        final Unit<Information> BYTE = systems.uom.unicode.CLDR.BYTE;
-        Unit<?> unit = pojo.parseUnits("test", "bytes");
-        assertEquals("Parsing bytes", unit, BYTE);
-    }
-
-    @Test
-    public void testSettingUnitsField() throws NoSuchFieldException, IllegalAccessException {
-        final Unit<Time> MILLISECONDS = MetricPrefix.MILLI(Units.SECOND);
-        final Specification pojo = new Specification();
-        pojo.unit = MILLISECONDS;
-        final Field unitField = pojo.getClass().getDeclaredField("unit");
-        unitField.setAccessible(true);
-        assertEquals("Unit not set", unitField.get(pojo), MILLISECONDS);
-    }
-
-    @Test
-    public void testSettingSemanticsField() throws NoSuchFieldException, IllegalAccessException {
-        final Specification pojo = new Specification();
-        pojo.semantics = ValueSemantics.CONSTANT;
-        final Field semanticsField = pojo.getClass().getDeclaredField("semantics");
-        semanticsField.setAccessible(true);
-        assertEquals("Semantics not set", semanticsField.get(pojo), ValueSemantics.CONSTANT);
-    }
-
-    public void testGetterOfStringField(String name) throws NoSuchFieldException, IllegalAccessException {
-        final String value = "test_" + name;
-        final Specification pojo = new Specification();
-        final Field field = pojo.getClass().getDeclaredField(name);
-        field.setAccessible(true);
-        field.set(pojo, value);
-        assertEquals(name + " not set", field.get(pojo), value);
-    }
-
-    @Test
-    public void testGetterGetsNameValue() throws NoSuchFieldException, IllegalAccessException {
-        testGetterOfStringField("name");
-    }
-
-    @Test
-    public void testGetterGetsDescriptionValue() throws NoSuchFieldException, IllegalAccessException {
-        testGetterOfStringField("description");
-    }
-
-    @Test
-    public void testGetterGetsMBeanNameValue() throws NoSuchFieldException, IllegalAccessException {
-        testGetterOfStringField("mBeanName");
-    }
-
-    @Test
-    public void testGetterGetsMBeanAttributeNameValue() throws NoSuchFieldException, IllegalAccessException {
-        testGetterOfStringField("mBeanAttributeName");
-    }
-
-    @Test
-    public void testGetterGetsMBeanCompositeDataItemValue() throws NoSuchFieldException, IllegalAccessException {
-        testGetterOfStringField("mBeanCompositeDataItem");
+        assertThat(specification.getUnits(), is(BYTE));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <unit.version>1.0</unit.version>
     <unit.se.version>1.0.4</unit.se.version>
     <unit.systems.version>0.6</unit.systems.version>
+    <unitils.version>3.4.3</unitils.version>
   </properties>
 
     <build>


### PR DESCRIPTION
Use the units of measurement parser instead of our own. Includes creating an alias for units that we already supported.