### PR TITLE
build: use docker for CI build

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Add extras missing in the docker image
+apt-get -qq update
+apt-get install -y apt-transport-https
+
+# Setup PCP
+wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
+echo "deb https://dl.bintray.com/pcp/stretch stretch main" >> /etc/apt/sources.list
+apt-get -qq update
+apt-get install -y pcp pcp-gui
+touch /var/lib/pcp/pmdas/mmv/.NeedInstall
+/etc/init.d/pmcd start
+
+# Run maven
+cd /parfait
+mvn -B -V clean install verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
-language: java
+language: bash
 
 dist: trusty
 sudo: required
+services:
+  - docker
 
-before_install:
-  - wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | sudo apt-key add -
-  - echo "deb https://dl.bintray.com/pcp/trusty trusty main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get -qq update
-  - sudo apt-get install -y pcp pcp-gui
-  - sudo touch /var/lib/pcp/pmdas/mmv/.NeedInstall
-  - sudo service pcp restart
-
-script: mvn -B -V clean install verify
+script: docker run -ti -v `pwd`:/parfait maven:3-jdk-8 /parfait/.ci.sh


### PR DESCRIPTION
Use Docker to do CI build. This fixes the issues with the current build breakage.