### PR TITLE
SEN-57 minor upgrade to CXF to fix compatibility issue with CXF

### DIFF
--- a/parfait-cxf/pom.xml
+++ b/parfait-cxf/pom.xml
@@ -5,7 +5,7 @@
     <version>0.3.10-SNAPSHOT</version>
   </parent>
   <properties>
-    <cxf.version>2.2.3</cxf.version>
+    <cxf.version>2.3.0</cxf.version>
   </properties>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.custardsource.parfait</groupId>

--- a/parfait-cxf/src/main/java/com/custardsource/parfait/cxf/MonitoringInterceptor.java
+++ b/parfait-cxf/src/main/java/com/custardsource/parfait/cxf/MonitoringInterceptor.java
@@ -33,7 +33,7 @@ public class MonitoringInterceptor extends AbstractPhaseInterceptor<XMLMessage> 
 		String methodName = operationResourceInfo.getMethodToInvoke().getName();
 		// TODO annotate with a better name?
 		Object key = operationResourceInfo.getClassResourceInfo().getResourceProvider()
-				.getInstance();
+				.getInstance(message);
 		if (!(key instanceof Timeable)) {
 			message.getInterceptorChain().doIntercept(message);
 			return;


### PR DESCRIPTION
CXF 2.3+ has no longer method getInstance() without param. This upgrade is just to fix that compatibility issue.