### PR TITLE
Library upgrades 2020

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -8,7 +8,7 @@ apt-get install -y apt-transport-https
 # Setup PCP
 wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
 #echo "deb https://dl.bintray.com/pcp/stretch stretch main" >> /etc/apt/sources.list
-apt-get update
+apt-get -qq update
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall
 /etc/init.d/pmcd start

--- a/.ci.sh
+++ b/.ci.sh
@@ -7,7 +7,7 @@ apt-get install -y apt-transport-https
 
 # Setup PCP
 wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
-#echo "deb https://dl.bintray.com/pcp/stretch stretch main" >> /etc/apt/sources.list
+echo "deb https://dl.bintray.com/pcp/bionic bionic main" >> /etc/apt/sources.list
 apt-get -qq update
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall

--- a/.ci.sh
+++ b/.ci.sh
@@ -6,9 +6,12 @@ apt-get -qq update
 apt-get install -y apt-transport-https
 
 # Setup PCP
-wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
-echo "deb https://dl.bintray.com/pcp/bionic bionic main" >> /etc/apt/sources.list
+# Due to Ubuntu/Python dependency hell, building against the latest PCP from bintray just doesn't install
+# TODO need to fix this - see Issue #69
+#wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
+#echo "deb https://dl.bintray.com/pcp/bionic bionic main" >> /etc/apt/sources.list
 apt-get -qq update
+#apt-get install -y python3.6
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall
 /etc/init.d/pmcd start

--- a/.ci.sh
+++ b/.ci.sh
@@ -7,11 +7,13 @@ apt-get install -y apt-transport-https
 
 # Setup PCP
 wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
-echo "deb https://dl.bintray.com/pcp/stretch stretch main" >> /etc/apt/sources.list
-apt-get -qq update
+#echo "deb https://dl.bintray.com/pcp/stretch stretch main" >> /etc/apt/sources.list
+apt-get update
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall
 /etc/init.d/pmcd start
+
+pcp
 
 # Run maven
 cd /parfait

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 
-dist: trusty
+dist: xenial
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 
-dist: xenial
+dist: bionic
 sudo: required
 services:
   - docker

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -76,7 +76,7 @@
       <plugin>
 	<groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>4.0.rc1</version>
         <inherited>false</inherited>
         <configuration>
           <skip>${license.skip}</skip>

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
 	<groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>4.0.rc1</version>
+        <version>${license-maven-plugin.version}</version>
         <inherited>false</inherited>
         <configuration>
           <skip>${license.skip}</skip>

--- a/parfait-benchmark/pom.xml
+++ b/parfait-benchmark/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.7</version>
+            <version>2.0.0-RC1</version>
         </dependency>
     </dependencies>
 </project>

--- a/parfait-cxf/pom.xml
+++ b/parfait-cxf/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
     	<groupId>com.thoughtworks.xstream</groupId>
     	<artifactId>xstream</artifactId>
-    	<version>1.3.1</version>
+    	<version>1.4.12</version>
     </dependency>
   </dependencies>  
 </project>

--- a/parfait-dropwizard/pom.xml
+++ b/parfait-dropwizard/pom.xml
@@ -63,5 +63,11 @@
             <version>${metrics3.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/parfait-spring/pom.xml
+++ b/parfait-spring/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib</artifactId>
-            <version>2.2</version>
+            <version>3.3.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.8.4</version>
+            <version>1.9.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.version>4.2.5.RELEASE</spring.version>
+    <spring.version>4.3.28.RELEASE</spring.version>
     <slf4j.version>1.6.1</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <jdk.version>1.8</jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>4.2.5.RELEASE</spring.version>
     <slf4j.version>1.6.1</slf4j.version>
-    <log4j.version>1.2.14</log4j.version>
+    <log4j.version>1.2.17</log4j.version>
     <jdk.version>1.8</jdk.version>
     <project.build.javaVersion>${jdk.version}</project.build.javaVersion>
     <maven.compile.targetLevel>${jdk.version}</maven.compile.targetLevel>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
@@ -136,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*IntegrationTest.java</exclude>
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.21.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -164,7 +164,7 @@
             <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.5.1</version>
+            <version>3.8.1</version>
             <configuration>
               <source>${java.major.source.version}</source>
               <target>${java.major.target.version}</target>
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -190,7 +190,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -199,10 +199,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.1.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 	    <plugin>
 	      <groupId>com.mycila</groupId>
               <artifactId>license-maven-plugin</artifactId>
-              <version>2.6</version>
+              <version>4.0.rc1</version>
               <inherited>false</inherited>
               <configuration>
                 <skip>${license.skip}</skip>
@@ -278,12 +298,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.0.5</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
           <dependency>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
-              <version>18.0</version>
+              <version>29.0-jre</version>
           </dependency>
           <dependency>
               <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
           <dependency>
               <groupId>org.mockito</groupId>
               <artifactId>mockito-core</artifactId>
-              <version>2.2.9</version>
+              <version>3.5.10</version>
           </dependency>
           <dependency>
               <groupId>net.jcip</groupId>
@@ -378,12 +378,12 @@
           <dependency>
               <groupId>commons-io</groupId>
               <artifactId>commons-io</artifactId>
-              <version>1.4</version>
+              <version>2.7</version>
           </dependency>
           <dependency>
               <groupId>commons-lang</groupId>
               <artifactId>commons-lang</artifactId>
-              <version>2.4</version>
+              <version>2.6</version>
           </dependency>
           <dependency>
               <groupId>org.springframework</groupId>
@@ -412,7 +412,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <unit.systems.version>0.6</unit.systems.version>
     <unitils.version>3.4.3</unitils.version>
     <jackson.version>2.11.2</jackson.version>
-      <license-maven-plugin.version>4.0.rc1</license-maven-plugin.version>
+    <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,12 +111,12 @@
     <maven.compile.sourceLevel>${jdk.version}</maven.compile.sourceLevel>
     <java.major.source.version>${jdk.version}</java.major.source.version>
     <java.major.target.version>${jdk.version}</java.major.target.version>
-    <metrics3.version>1.0.2</metrics3.version>
+    <metrics3.version>2.0.13</metrics3.version>
     <unit.version>1.0</unit.version>
     <unit.se.version>1.0.4</unit.se.version>
     <unit.systems.version>0.6</unit.systems.version>
     <unitils.version>3.4.3</unitils.version>
-    <jackson.version>2.8.8</jackson.version>
+    <jackson.version>2.11.2</jackson.version>
   </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <unit.systems.version>0.6</unit.systems.version>
     <unitils.version>3.4.3</unitils.version>
     <jackson.version>2.11.2</jackson.version>
+      <license-maven-plugin.version>4.0.rc1</license-maven-plugin.version>
   </properties>
 
     <build>
@@ -222,7 +223,7 @@
 	    <plugin>
 	      <groupId>com.mycila</groupId>
               <artifactId>license-maven-plugin</artifactId>
-              <version>4.0.rc1</version>
+              <version>${license-maven-plugin.version}</version>
               <inherited>false</inherited>
               <configuration>
                 <skip>${license.skip}</skip>


### PR DESCRIPTION
This series of commits brings various Library and Plugin dependencies up to latest, with one caveat being `parfait-cxf`. All dependency (according to dependencyBot at least) should be addressed here. 

`parfait-cxf` is left as is (other than a minor `xstream` update for security) as Aconex still needs this version as is for the moment - I think this sub-module probably needs to be its own standalone module anyway.

I'd like to bring these to master before a smaller 2nd pass to tidy up build warnings, and preparation for a release.