### PR TITLE
Build & test Parfait against latest PCP builds

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 set -e
+export DEBIAN_FRONTEND=noninteractive
 
-# Add extras missing in the docker image
-apt-get -qq update
-apt-get install -y apt-transport-https
-
-# Setup PCP
-# Due to Ubuntu/Python dependency hell, building against the latest PCP from bintray just doesn't install
-# TODO need to fix this - see Issue #69
+apt-get update
+apt-get install -y wget gnupg ca-certificates
 wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
 echo "deb https://dl.bintray.com/pcp/focal focal main" >> /etc/apt/sources.list
 apt-get -qq update
-#apt-get install -y python3.6
+
+# prompts for timezone stuff?
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall
 /etc/init.d/pmcd start
 
 pcp
+
+# Java8
+apt-get install -y openjdk-8-jdk
+
+# would pull in Java11 if Java8 wasn't installed
+apt-get install -y maven
 
 # Run maven
 cd /parfait

--- a/.ci.sh
+++ b/.ci.sh
@@ -8,8 +8,8 @@ apt-get install -y apt-transport-https
 # Setup PCP
 # Due to Ubuntu/Python dependency hell, building against the latest PCP from bintray just doesn't install
 # TODO need to fix this - see Issue #69
-#wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
-#echo "deb https://dl.bintray.com/pcp/bionic bionic main" >> /etc/apt/sources.list
+wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-key add -
+echo "deb https://dl.bintray.com/pcp/focal focal main" >> /etc/apt/sources.list
 apt-get -qq update
 #apt-get install -y python3.6
 apt-get install -y pcp pcp-gui

--- a/.ci.sh
+++ b/.ci.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+#ensure no prompts for stuff like timezones
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
@@ -8,7 +9,6 @@ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=pcp | apt-
 echo "deb https://dl.bintray.com/pcp/focal focal main" >> /etc/apt/sources.list
 apt-get -qq update
 
-# prompts for timezone stuff?
 apt-get install -y pcp pcp-gui
 touch /var/lib/pcp/pmdas/mmv/.NeedInstall
 /etc/init.d/pmcd start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 
-dist: bionic
+dist: focal
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ sudo: required
 services:
   - docker
 
-script: docker run -ti -v `pwd`:/parfait maven:3-jdk-8 /parfait/.ci.sh
+script: docker run -ti -v `pwd`:/parfait  ubuntu:focal /parfait/.ci.sh


### PR DESCRIPTION
Fixes #69 

This change fixes the TravisCI build to ensure it builds against the latest published PCP builds at Bintray.

It changes from the original Maven3 Docker image (which used some outdated distro) to a Ubuntu 'focal' distro that then install JDK8 and Maven before building.

Other than downloading the internet, this seems to work.  Only takes 3 minutes.