### PR TITLE
UnitMapping bug

### DIFF
--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
@@ -146,15 +146,4 @@ public final class UnitMapping {
     private static int to4Bits(UnitValued valued) {
         return valued == null ? 0 : (valued.getPmUnitsValue() & 0xf);
     }
-
-    public static void main(String[] args) {
-        System.out.println(UnitMapping.findUnitMapping(BYTE));
-        System.out.println(UnitMapping.findUnitMapping(BYTE.divide(SECOND)));
-        System.out.println(UnitMapping.findUnitMapping(BYTE.multiply(1024).divide(SECOND)));
-        System.out.println(UnitMapping.findUnitMapping(BYTE.multiply(1024).divide(SECOND.divide(1000))));
-        System.out.println(UnitMapping.findUnitMapping(ONE.multiply(1000).divide(SECOND)));
-        System.out.println(UnitMapping.findUnitMapping(ONE.multiply(1000).divide(SECOND.divide(1000))));
-        System.out.println(UnitMapping.findUnitMapping(ONE.multiply(500).divide(SECOND.divide(2))));
-        System.out.println(UnitMapping.findUnitMapping(ONE.multiply(50).divide(BIT)));
-    }
 }

--- a/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/semantics/UnitMapping.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import io.pcp.parfait.dxm.semantics.PcpScale.SpaceScale;
 import io.pcp.parfait.dxm.semantics.PcpScale.TimeScale;
 import io.pcp.parfait.dxm.semantics.PcpScale.UnitScale;
+import tech.units.indriya.unit.UnitDimension;
 
 public final class UnitMapping {
     private static final Logger LOG = LoggerFactory.getLogger(UnitMapping.class);
@@ -75,7 +76,7 @@ public final class UnitMapping {
             return false;
         }
         Unit<?> divided = left.divide(right);
-        if (!divided.getDimension().equals(Dimension.NONE)) {
+        if (!divided.getDimension().equals(UnitDimension.NONE)) {
             return false;
         }
         return divided.asType(Dimensionless.class).getConverterTo(ONE).equals(IDENTITY);

--- a/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2017 Aconex
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package io.pcp.parfait.dxm.semantics;
 
 import static org.junit.Assert.assertNotNull;

--- a/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
@@ -31,13 +31,16 @@ public class UnitMappingTest {
 
     @Test
     public void getUnitMapping_whenTimeAndDerivativeUnitsGiven() {
-        UnitMapping milliSeconds = UnitMapping.findUnitMapping(MetricPrefix.MILLI(SECOND));
+        UnitMapping milliSeconds = UnitMapping.findUnitMapping(SECOND.divide(1000));
         assertNotNull(milliSeconds);
 
-        UnitMapping onePerMinute = UnitMapping.findUnitMapping(AbstractUnit.ONE.divide(Units.MINUTE));
-        assertNotNull(onePerMinute);
+        UnitMapping milliSeconds1 = UnitMapping.findUnitMapping(MetricPrefix.MILLI(SECOND));
+        assertNotNull(milliSeconds1);
 
         UnitMapping milliSeconds2 = UnitMapping.findUnitMapping(MILLISECOND);
         assertNotNull(milliSeconds2);
+
+        UnitMapping onePerMinute = UnitMapping.findUnitMapping(AbstractUnit.ONE.divide(Units.MINUTE));
+        assertNotNull(onePerMinute);
     }
 }

--- a/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
+++ b/dxm/src/test/java/io/pcp/parfait/dxm/semantics/UnitMappingTest.java
@@ -1,0 +1,43 @@
+package io.pcp.parfait.dxm.semantics;
+
+import static org.junit.Assert.assertNotNull;
+import static systems.uom.unicode.CLDR.BIT;
+import static systems.uom.unicode.CLDR.BYTE;
+import static tech.units.indriya.quantity.time.TimeQuantities.MILLISECOND;
+import static tech.units.indriya.unit.Units.SECOND;
+
+import javax.measure.MetricPrefix;
+
+import org.junit.Test;
+import tech.units.indriya.AbstractUnit;
+import tech.units.indriya.unit.Units;
+
+public class UnitMappingTest {
+
+    @Test
+    public void getUnitMapping_whenByteAndDerivativeUnitsGiven() {
+        UnitMapping byteUnitMapping = UnitMapping.findUnitMapping(BYTE);
+        assertNotNull(byteUnitMapping);
+
+        UnitMapping bytePerSecondUnitMapping = UnitMapping.findUnitMapping(BYTE.divide(SECOND));
+        assertNotNull(bytePerSecondUnitMapping);
+
+        UnitMapping bytePerMilliSecondUnitMapping = UnitMapping.findUnitMapping(BYTE.divide(SECOND.divide(1000)));
+        assertNotNull(bytePerMilliSecondUnitMapping);
+
+        UnitMapping bitUnitMapping = UnitMapping.findUnitMapping(BIT);
+        assertNotNull(bitUnitMapping);
+    }
+
+    @Test
+    public void getUnitMapping_whenTimeAndDerivativeUnitsGiven() {
+        UnitMapping milliSeconds = UnitMapping.findUnitMapping(MetricPrefix.MILLI(SECOND));
+        assertNotNull(milliSeconds);
+
+        UnitMapping onePerMinute = UnitMapping.findUnitMapping(AbstractUnit.ONE.divide(Units.MINUTE));
+        assertNotNull(onePerMinute);
+
+        UnitMapping milliSeconds2 = UnitMapping.findUnitMapping(MILLISECOND);
+        assertNotNull(milliSeconds2);
+    }
+}


### PR DESCRIPTION
UnitMapping is unable to find units that are generated through `MetricPrefix`. For example following returns `null`

```java
UnitMapping.findUnitMapping(MetricPrefix.MILLI(SECOND))
```
There is a type mismatch when comparing the dimension of a unit. (Ref: `UnitMapping.java:78`) which is causing this.