### PR TITLE
Transition parfait agent and core to using slf4j exclusively

### DIFF
--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -155,11 +155,6 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/parfait-agent/src/main/java/io/pcp/parfait/AgentMonitoringView.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/AgentMonitoringView.java
@@ -48,11 +48,12 @@ import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.measure.Unit;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 class AgentMonitoringView {
-    private static final Logger logger = Logger.getLogger(ParfaitAgent.class);
+    private static final Logger logger = LoggerFactory.getLogger(ParfaitAgent.class);
 
     private MonitorableRegistry registry = MonitorableRegistry.DEFAULT_REGISTRY;
 

--- a/parfait-agent/src/main/java/io/pcp/parfait/JmxUtilities.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/JmxUtilities.java
@@ -29,8 +29,6 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.log4j.Logger;
-
 /**
  * Convenience mechanisms for locating MBeanServer classes.
  */

--- a/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
+++ b/parfait-agent/src/main/java/io/pcp/parfait/ParfaitAgent.java
@@ -34,10 +34,11 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ParfaitAgent {
-    private static final Logger logger = Logger.getLogger(ParfaitAgent.class);
+    private static final Logger logger = LoggerFactory.getLogger(ParfaitAgent.class);
     private static final SpecificationAdapter specificationAdapter = new SpecificationAdapter();
 
     private static final String RESOURCE = "/jvm.json";

--- a/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
@@ -20,14 +20,15 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import com.google.common.base.Supplier;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Designed to run code after the MonitorableRegistry has become quiet, in terms of addition of new metrics
  */
 public class QuiescentRegistryListener implements MonitorableRegistryListener {
 
-    private static final Logger LOG = Logger.getLogger(QuiescentRegistryListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuiescentRegistryListener.class);
 
     private final Scheduler quiescentScheduler;
     private volatile long lastTimeMonitorableAdded = 0;

--- a/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadContext.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/timing/ThreadContext.java
@@ -95,11 +95,6 @@ public class ThreadContext {
      * Clears all values for the current thread.
      */
     public void clear() {
-
-        /**
-         * Unfortunately log4j's MDC historically never had a mechanism to block remove keys,
-         * so we're forced to do this one by one.
-         */
         for (String key : allKeys()) {
            mdcBridge.remove(key);
         }
@@ -127,21 +122,18 @@ public class ThreadContext {
     }
 
     /**
-     * Factory method that creates a new ThreadContext initialized to also update Log4j's MDC.
+     * Factory methods that create a new ThreadContext initialised to also update SLF4J's MDC
      */
     public static ThreadContext newMDCEnabledContext() {
-        return new ThreadContext(new Log4jMdcBridge());
+        return newSLF4JEnabledContext();
     }
 
-    /**
-     * Factory method that creates a new ThreadContext initialised to also update SLF4J's MDC
-     */
     public static ThreadContext newSLF4JEnabledContext() {
         return new ThreadContext(new Slf4jMDCBridge());
     }
 
     public interface MdcBridge {
-    	void put(String key, Object object);
+		void put(String key, Object object);
 
 		void remove(String key);
     }
@@ -158,18 +150,6 @@ public class ThreadContext {
 		}
     }
     
-    public static class Log4jMdcBridge implements MdcBridge {
-		@Override
-		public void put(String key, Object object) {
-			org.apache.log4j.MDC.put(key, object);
-		}
-
-		@Override
-		public void remove(String key) {
-			org.apache.log4j.MDC.remove(key);
-		}
-	}
-
     public static class Slf4jMDCBridge implements MdcBridge {
 		@Override
 		public void put(String key, Object object) {

--- a/parfait-core/src/test/java/io/pcp/parfait/timing/ThreadContextTest.java
+++ b/parfait-core/src/test/java/io/pcp/parfait/timing/ThreadContextTest.java
@@ -20,7 +20,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import org.apache.log4j.MDC;
+import org.slf4j.MDC;
 
 import junit.framework.TestCase;
 
@@ -29,11 +29,7 @@ public class ThreadContextTest extends TestCase {
     
     public void setUp() {
         context = new ThreadContext();
-
-        Hashtable hashtable = MDC.getContext();
-        if (hashtable != null) {
-            hashtable.clear();
-        }
+        MDC.clear();
     }
 
 
@@ -86,15 +82,16 @@ public class ThreadContextTest extends TestCase {
         assertNull("get() after clear should return null", context.get(testKey));
     }
 
+/* -- Slf4j provides no MDC context API --
     public void testClearRemovesMDCValue() {
 
-        ThreadContext log4jThreadContext = ThreadContext.newMDCEnabledContext();
+        ThreadContext logThreadContext = ThreadContext.newMDCEnabledContext();
 
         Hashtable mdcContext = MDC.getContext();
         assertTrue(mdcContext == null || mdcContext.isEmpty());
 
         final String testKey = "painter";
-        log4jThreadContext.put(testKey, 7);
+        logThreadContext.put(testKey, 7);
 
         mdcContext = MDC.getContext();
         assertEquals(1, mdcContext.size());
@@ -102,7 +99,8 @@ public class ThreadContextTest extends TestCase {
         mdcContext.clear();
         assertEquals(0, mdcContext.size());
 
-        log4jThreadContext.clear();
-        assertNull("get() after clear should return null", log4jThreadContext.get(testKey));
+        logThreadContext.clear();
+        assertNull("get() after clear should return null", logThreadContext.get(testKey));
     }
+*/
 }

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>4.3.28.RELEASE</spring.version>
     <slf4j.version>1.6.1</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
     <jdk.version>1.8</jdk.version>
     <project.build.javaVersion>${jdk.version}</project.build.javaVersion>
     <maven.compile.targetLevel>${jdk.version}</maven.compile.targetLevel>
@@ -378,11 +377,6 @@
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-api</artifactId>
            <version>${slf4j.version}</version>
-         </dependency>
-          <dependency>
-              <groupId>log4j</groupId>
-              <artifactId>log4j</artifactId>
-              <version>${log4j.version}</version>
           </dependency>
           <dependency>
               <groupId>com.google.guava</groupId>
@@ -443,11 +437,6 @@
     <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
We had previously a handful of places using Log4J explicitly;
these are now transitioned to use the Slf4J wrappers only and
in the case of parfait-agent defaulting to slf4j-simple (when
no other logger is available / configured).

This change removes last dependencies on Log4J in Parfait - a
developer can still choose to use Log4J with Parfait of course
but that is now an explicit, opt-in choice.

Resolves Red Hat BZ #2031674