### PR TITLE
Fix parfait-dropwizard tests with recent jvm versions

### DIFF
--- a/parfait-dropwizard/pom.xml
+++ b/parfait-dropwizard/pom.xml
@@ -58,6 +58,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>2.13.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-configuration</artifactId>
             <version>${metrics3.version}</version>


### PR DESCRIPTION
java.util.concurrent.TimeUnit is nowadays a final class,
so an updated version of mockito is needed to to mock it
otherwise this error is encountered:

io.pcp.parfait.dropwizard.ParfaitReporterTest.shouldOnlyPublishOnlyPreviouslyUnseenMetricsDuringReport
Cannot mock/spy class java.util.concurrent.TimeUnit
Mockito cannot mock/spy because :
 - final class