### PR TITLE
Move all mockito versioning to top level pom.xml file

### DIFF
--- a/parfait-dropwizard/pom.xml
+++ b/parfait-dropwizard/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <unit.systems.version>2.0.2</unit.systems.version>
     <unitils.version>3.4.3</unitils.version>
     <jackson.version>2.11.2</jackson.version>
+    <mockito.version>3.12.4</mockito.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 
@@ -386,7 +387,12 @@
           <dependency>
               <groupId>org.mockito</groupId>
               <artifactId>mockito-core</artifactId>
-              <version>3.5.10</version>
+              <version>${mockito.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-inline</artifactId>
+              <version>${mockito.version}</version>
           </dependency>
           <dependency>
               <groupId>net.jcip</groupId>


### PR DESCRIPTION
Update to the most recent 3.x version of mockito for
both mockito-core and mockito-inline.  Also ensure we
use the same version for both and maintain this in the
top level pom for the whole project for consistency.

Thanks TallPaul for the code review.