### PR TITLE
Migrate parfait-cxf from cxf-api:2.2.3 to cxf-core 4.0.3

### DIFF
--- a/parfait-cxf/pom.xml
+++ b/parfait-cxf/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.2-SNAPSHOT</version>
   </parent>
   <properties>
-    <cxf.version>2.2.3</cxf.version>
+    <cxf.version>4.0.3</cxf.version>
   </properties>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>
@@ -54,7 +54,7 @@
     </dependency>
     <dependency>
     	<groupId>org.apache.cxf</groupId>
-    	<artifactId>cxf-api</artifactId>
+    	<artifactId>cxf-core</artifactId>
         <version>${cxf.version}</version>
     	<type>jar</type>
     	<scope>compile</scope>

--- a/parfait-cxf/src/main/java/io/pcp/parfait/cxf/MonitoringInterceptor.java
+++ b/parfait-cxf/src/main/java/io/pcp/parfait/cxf/MonitoringInterceptor.java
@@ -49,7 +49,7 @@ public class MonitoringInterceptor extends AbstractPhaseInterceptor<XMLMessage> 
 		String methodName = operationResourceInfo.getMethodToInvoke().getName();
 		// TODO annotate with a better name?
 		Object key = operationResourceInfo.getClassResourceInfo().getResourceProvider()
-				.getInstance();
+				.getInstance(message);
 		if (!(key instanceof Timeable)) {
 			message.getInterceptorChain().doIntercept(message);
 			return;

--- a/parfait-cxf/src/test/java/io/pcp/parfait/cxf/RestDemo.java
+++ b/parfait-cxf/src/test/java/io/pcp/parfait/cxf/RestDemo.java
@@ -16,9 +16,9 @@
 
 package io.pcp.parfait.cxf;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 import io.pcp.parfait.timing.EventTimer;
 import io.pcp.parfait.timing.Timeable;


### PR DESCRIPTION
Also bumped cxf-rt-transports-http/cxf-rt-frontend-jaxrs/cxf-testutils from 2.2.3 to 4.0.3