### PR TITLE
fix PcpMmvWriter memory leak

### DIFF
--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
@@ -340,6 +340,7 @@ public class PcpMmvWriter implements PcpWriter {
     public void reset() {
         started = false;
         metricData.clear();
+        perMetricByteBuffers.clear();
     }
 
     @Override


### PR DESCRIPTION
The `perMetricsByteBuffers` map leaks in `PcpMmvWriter` as follows:

1. A new metric is added.
2. Skipping some plumbing, `PcpMmvWriter.stop()` is called, which clears `PcpMmvWriter.metricData`, which is a map of `PcpValueInfo` objects that describe all of the metrics.
3. All of the metrics are re-added with calls to `PcpMmvWriter.addMetricInfo()`, which creates new `PcpValueInfo` instances to repoplulate `PcpMmvWriter.metricData`.
4. `PcpMmvWriter.start()` is called, which creates a new `ByteBuffer`, and populates slices of the buffer into
`PcpMmvWriter.perMetricByteBuffers`. This map is keyed off the new `PcpValueInfo` instances, and this is where it's leaking.

This fixes the leak by clearing the map when `PcpMmvWriter.reset()` is called. This is safe because that method also clears `PcpMmvWriter.metricData`, which is assumed to be insync with `perMetricByteBuffers`. Clearing the map allows the old `PcpValueInfo` objects to be GC'd as well as the backing `DirectByteBuffer`.