### PR TITLE
fix `QuiescentRegistryListener` leak

### DIFF
--- a/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
+++ b/parfait-core/src/main/java/io/pcp/parfait/QuiescentRegistryListener.java
@@ -48,6 +48,7 @@ public class QuiescentRegistryListener implements MonitorableRegistryListener {
                 synchronized (lock) {
                     if (lastTimeMonitorableAdded > 0 && clock.get().longValue() >= (lastTimeMonitorableAdded + quietPeriodInMillis)) {
                         LOG.info(String.format("New Monitorables detected after quiet period of %dms", quietPeriodInMillis));
+                        cancel();
                         runnable.run();
                         lastTimeMonitorableAdded = 0;
                     }


### PR DESCRIPTION
`QuiescentRegistryListener` instances leak because they are never canceled. `QuiescentRegistryListener` instances are essentially single use, and should be cancaled after they detected monitorable changes. The reason for this is because the embedded runnable calls `DynamicMonitoringView.stop()` immediately followed by `DynamicMonitoringView.start()`. This call to `DynamicMonitoringView.start()` installs a new `QuiescentRegistryListener` instance.