### PR TITLE
update dependencies

### DIFF
--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -58,10 +58,6 @@
         <artifactId>systems-unicode</artifactId>
     </dependency>
     <dependency>
-    	<groupId>commons-lang</groupId>
-    	<artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
     	<groupId>commons-io</groupId>
     	<artifactId>commons-io</artifactId>
     </dependency>
@@ -73,7 +69,6 @@
     <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
-      <version>${unitils.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dxm/src/main/java/io/pcp/parfait/dxm/FileByteBufferFactory.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/FileByteBufferFactory.java
@@ -16,9 +16,6 @@
 
 package io.pcp.parfait.dxm;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -71,7 +68,7 @@ public class FileByteBufferFactory implements ByteBufferFactory {
     @Override
     public String toString() {
         try {
-            return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("file", file.getCanonicalPath()).toString();
+            return "FileByteBufferFactory[file=" + file.getCanonicalPath() + ']';
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
@@ -55,8 +55,6 @@ import io.pcp.parfait.dxm.types.MmvMetricType;
 import io.pcp.parfait.dxm.types.TypeHandler;
 import com.google.common.base.Preconditions;
 import net.jcip.annotations.GuardedBy;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
 
 /**
  * <p>
@@ -770,7 +768,6 @@ public class PcpMmvWriter implements PcpWriter {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("byteBufferFactory", this.byteBufferFactory).toString();
+        return "PcpMmvWriter[byteBufferFactory=" + byteBufferFactory + ']';
     }
-
 }

--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -127,7 +127,6 @@
     <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
-      <version>${unitils.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -146,28 +145,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/parfait-benchmark/pom.xml
+++ b/parfait-benchmark/pom.xml
@@ -104,5 +104,9 @@
             <artifactId>jcommander</artifactId>
             <version>1.72</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTest.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/CPUThreadTest.java
@@ -33,7 +33,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class CPUThreadTest {
 

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/ReportHelper.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/ReportHelper.java
@@ -20,7 +20,7 @@ import static java.net.InetAddress.getLocalHost;
 
 import java.net.UnknownHostException;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 public class ReportHelper {
     static void environmentReportHeader()  {

--- a/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/StandardMetricThroughPutBenchmark.java
+++ b/parfait-benchmark/src/main/java/io/pcp/parfait/benchmark/StandardMetricThroughPutBenchmark.java
@@ -40,7 +40,7 @@ import io.pcp.parfait.pcp.MetricNameMapper;
 import io.pcp.parfait.pcp.PcpMonitorBridge;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class StandardMetricThroughPutBenchmark {
 

--- a/parfait-cxf/pom.xml
+++ b/parfait-cxf/pom.xml
@@ -22,7 +22,7 @@
     <version>1.2.1-SNAPSHOT</version>
   </parent>
   <properties>
-    <cxf.version>4.0.3</cxf.version>
+    <cxf.version>4.0.5</cxf.version>
   </properties>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.pcp.parfait</groupId>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
-      <version>5.2.20.RELEASE</version>
+      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>3.0.5.RELEASE</version>
+      <version>${spring.version}</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.cxf</groupId>
@@ -78,7 +78,7 @@
     <dependency>
     	<groupId>org.mortbay.jetty</groupId>
     	<artifactId>jetty</artifactId>
-    	<version>6.1.23</version>
+    	<version>6.1.26</version>
     	<scope>test</scope>
     </dependency>
     <dependency>

--- a/parfait-dropwizard/pom.xml
+++ b/parfait-dropwizard/pom.xml
@@ -58,21 +58,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-configuration</artifactId>
             <version>${metrics3.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parfait-spring/pom.xml
+++ b/parfait-spring/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.9.6</version>
+            <version>1.9.22.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,21 +103,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.version>5.3.27</spring.version>
-    <slf4j.version>1.6.1</slf4j.version>
+    <spring.version>5.3.39</spring.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <jdk.version>1.8</jdk.version>
     <project.build.javaVersion>${jdk.version}</project.build.javaVersion>
     <maven.compile.targetLevel>${jdk.version}</maven.compile.targetLevel>
     <maven.compile.sourceLevel>${jdk.version}</maven.compile.sourceLevel>
     <java.major.source.version>${jdk.version}</java.major.source.version>
     <java.major.target.version>${jdk.version}</java.major.target.version>
-    <metrics3.version>2.0.13</metrics3.version>
-    <unit.version>2.0</unit.version>
-    <unit.ri.version>2.0.4</unit.ri.version>
-    <unit.systems.version>2.0.2</unit.systems.version>
-    <unitils.version>3.4.3</unitils.version>
-    <jackson.version>2.16.0</jackson.version>
-    <mockito.version>4.3.1</mockito.version>
+    <metrics3.version>2.0.35</metrics3.version>
+    <unit.version>2.2</unit.version>
+    <unit.ri.version>2.2</unit.ri.version>
+    <unit.systems.version>2.1</unit.systems.version>
+    <unitils.version>3.4.6</unitils.version>
+    <jackson.version>2.17.2</jackson.version>
+    <mockito.version>5.13.0</mockito.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 
@@ -373,18 +373,18 @@
            <version>${slf4j.version}</version>
           </dependency>
           <dependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-simple</artifactId>
+              <version>${slf4j.version}</version>
+          </dependency>
+          <dependency>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
-              <version>32.1.3-jre</version>
+              <version>33.3.0-jre</version>
           </dependency>
           <dependency>
               <groupId>org.mockito</groupId>
               <artifactId>mockito-core</artifactId>
-              <version>${mockito.version}</version>
-          </dependency>
-          <dependency>
-              <groupId>org.mockito</groupId>
-              <artifactId>mockito-inline</artifactId>
               <version>${mockito.version}</version>
           </dependency>
           <dependency>
@@ -395,12 +395,12 @@
           <dependency>
               <groupId>commons-io</groupId>
               <artifactId>commons-io</artifactId>
-              <version>2.7</version>
+              <version>2.16.1</version>
           </dependency>
           <dependency>
-              <groupId>commons-lang</groupId>
-              <artifactId>commons-lang</artifactId>
-              <version>2.6</version>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-lang3</artifactId>
+              <version>3.16.0</version>
           </dependency>
           <dependency>
               <groupId>org.springframework</groupId>
@@ -422,6 +422,26 @@
               <artifactId>hamcrest-all</artifactId>
               <version>1.3</version>
           </dependency>
+          <dependency>
+              <groupId>org.unitils</groupId>
+              <artifactId>unitils-core</artifactId>
+              <version>${unitils.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+              <version>${jackson.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <version>${jackson.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>${jackson.version}</version>
+          </dependency>
       </dependencies>
   </dependencyManagement>
 
@@ -429,7 +449,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>
@@ -440,17 +460,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
1. Updates most dependencies, while trying to avoid potential breaking changes.
2. Removes commons-lang as a dependency of dxm, because it was only being used for ToStringBuilder.