### PR TITLE
fix parfait-agent packaging

### DIFF
--- a/parfait-agent/pom.xml
+++ b/parfait-agent/pom.xml
@@ -62,16 +62,15 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Premain-Class>io.pcp.parfait.ParfaitAgent</Premain-Class>
+              <Main-Class>io.pcp.parfait.ParfaitAgent</Main-Class>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
 	<groupId>com.mycila</groupId>


### PR DESCRIPTION
The parfait-agent jar now correctly contains the `Premain-Class` property, and it no longer contains a bundled copy of all of the dependencies. The version with bundled dependencies is still generated under the `jar-with-dependencies` classifier.

resolves https://github.com/performancecopilot/parfait/issues/125