### PR TITLE
fix PcpMmvWriter strings leak

### DIFF
--- a/dxm/pom.xml
+++ b/dxm/pom.xml
@@ -76,7 +76,10 @@
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
-
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpMmvWriter.java
@@ -339,6 +339,9 @@ public class PcpMmvWriter implements PcpWriter {
         started = false;
         metricData.clear();
         perMetricByteBuffers.clear();
+        instanceDomainStore.clear();
+        metricInfoStore.clear();
+        stringStore.clear();
     }
 
     @Override
@@ -763,6 +766,11 @@ public class PcpMmvWriter implements PcpWriter {
 
         synchronized int size() {
             return byName.size();
+        }
+
+        synchronized void clear() {
+            byId.clear();
+            byName.clear();
         }
     }
 

--- a/dxm/src/main/java/io/pcp/parfait/dxm/PcpString.java
+++ b/dxm/src/main/java/io/pcp/parfait/dxm/PcpString.java
@@ -81,6 +81,9 @@ final class PcpString implements PcpOffset,MmvWritable {
             return stringInfo;
         }
 
+        void clear() {
+            stringInfo.clear();
+        }
     }
 
 }


### PR DESCRIPTION
`PcpMmvWriter` leaks strings through its `PcpStringStore` when the writer is reset. The fix is to clear the store in the reset method. However, the `metricInfoStore` and `instanceDomainStore` rely on putting values in the string store when MMV2 is used. As such, these stores must also be cleared so that the strings can be recreated.

Resolves https://github.com/performancecopilot/parfait/issues/38